### PR TITLE
A Bug Fix for BrainPy Array Extension for Compatibility of Pytorch 张泽清 2023-2-8

### DIFF
--- a/brainpy/_src/math/ndarray.py
+++ b/brainpy/_src/math/ndarray.py
@@ -1057,7 +1057,7 @@ class Array(object):
       out.value = jnp.abs(self.value)
     return _return(jnp.abs(self.value))
 
-  def abs_(self) -> BmArray:
+  def abs_(self) -> None:
     """
     in-place version of Array.abs()
     """
@@ -1072,11 +1072,11 @@ class Array(object):
       out.value = jnp.abs(self.value)
     return _return(jnp.abs(self.value))
 
-  def absolute_(self) -> BmArray:
+  def absolute_(self) -> None:
     """
     alias of Array.abs_()
     """
-    return self.abs_()
+    self.value = jnp.abs(self.value)
 
   def sin(self, *, out: OptionalBmArray = None) -> BmArray:
     '''

--- a/brainpy/_src/math/ndarray.py
+++ b/brainpy/_src/math/ndarray.py
@@ -1042,6 +1042,8 @@ class Array(object):
       raise TypeError(F'Wrong beta param of addr, need num(int or float) but got {type(beta)}')
     if not isinstance(alpha, int) and not isinstance(alpha, float):
       raise TypeError(F'Wrong alpha param of addr, need num(int or float) but got {type(alpha)}')
+    _bmarray_or_except(vec1)
+    _bmarray_or_except(vec2)
     self.value = beta * self.value + jnp.outer(vec1, vec2)
 
   def outer(self, other: BmArray) -> Union[NoReturn, None]:

--- a/brainpy/_src/math/tests/test_array_pytorch.py
+++ b/brainpy/_src/math/tests/test_array_pytorch.py
@@ -1,0 +1,413 @@
+import unittest
+
+import traceback
+import brainpy.math as bm
+
+class TestArrayPytorch(unittest.TestCase):
+  def test_sin(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.sin(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_sin_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.sin_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_sin(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.sin(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_sin_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.sin_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_sinh(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.sinh(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_sinh_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.sinh_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_sinh(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.sinh(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_sinh_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.sinh_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arcsin(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.arcsin(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arcsin_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.arcsin_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arcsin(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.arcsin(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arcsin_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.arcsin_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arcsinh(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.arcsinh(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arcsinh_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.arcsinh_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arcsinh(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.arcsinh(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arcsinh_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.arcsinh_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_cos(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.cos(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_cos_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.cos_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_cos(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.cos(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_cos_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.cos_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_cosh(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.cosh(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_cosh_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.cosh_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_cosh(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.cosh(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_cosh_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.cosh_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arccos(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.arccos(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arccos_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.arccos_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arccos(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.arccos(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arccos_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.arccos_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arccosh(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.arccosh(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arccosh_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.arccosh_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arccosh(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.arccosh(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arccosh_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.arccosh_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_tan(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.tan(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_tan_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.tan_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_tan(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.tan(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_tan_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.tan_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_tanh(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.tanh(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_tanh_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.tanh_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_tanh(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.tanh(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_tanh_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.tanh_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arctan(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.arctan(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arctan_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.arctan_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arctan(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.arctan(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arctan_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.arctan_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arctanh(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.arctanh(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arctanh_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.arctanh_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arctanh(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      b = bm.Array([-1, -1, -1], dtype=float)
+      c = a.arctanh(out=b)
+      print(c, b)
+    except Exception as e:
+      traceback.print_exc()
+
+  def test_arctanh_(self):
+    try:
+      a = bm.Array([0, -2, 3], dtype=float)
+      a.arctanh_()
+      print(a)
+    except Exception as e:
+      traceback.print_exc()


### PR DESCRIPTION
# A Bug Fix for `BrainPy Array Extension for Compatibility of Pytorch`  张泽清 2023-2-8

## Description

对[原问题](https://github.com/brainpy/BrainPy/pull/334#discussion_r1099734685)的Bug修复

原问题链接`https://github.com/brainpy/BrainPy/pull/334#discussion_r1099734685`

### Tensor Type

+ 要求输入的算子的类型必须为`BrainPy Array`，例如，`arr.abs(out)`，若out的类型不是`BrainPy Array`，则会抛出`TypeError`
    ```python
    # Before
    BmArray = Union["Array", jax.Array, np.ndarray] 
    if not isinstance(out, (Array, jax.Array, np.ndarray)):
      ...
  
    # After
    BmArray = "Array" 
    if not isinstance(out, Array):
      ...
    ```

+ 修复了错误的调用，`jnp.some_func(out=arr)`，去除了`out`传参，因为`jnp`不支持`out`
    ```python
    # Before
    ...
    jnp.some_func(out=arr)
    ...
  
    # After
    ...
    out.value = jnp.some_func()
    ...
    ```
+ 其他略

## Testing
Tested by *`brainpy/_src/math/tests/test_array_pytorch.py`*
- [x] Trigonometric function.
- [x] Base function, such as abs, copy, clone.
- [ ] Calc function.
- [ ] Pytorch package function


## Other information
None