### PR TITLE
[fix] bug of `connect.base.py`'s `require` function

### DIFF
--- a/brainpy/_src/connect/base.py
+++ b/brainpy/_src/connect/base.py
@@ -425,7 +425,7 @@ class TwoEndConnector(Connector):
           return bm.as_jax(self.build_coo()[0], dtype=IDX_DTYPE)
         elif POST_IDS in structures and _has_coo_imp:
           return bm.as_jax(self.build_coo()[1], dtype=IDX_DTYPE)
-        elif COO in structures and not _has_coo_imp:
+        elif COO in structures and _has_coo_imp:
           return bm.as_jax(self.build_coo(), dtype=IDX_DTYPE)
 
       elif len(structures) == 2:


### PR DESCRIPTION
## Description
The bug is on the line 428 of `connect/base.py`
```
elif COO in structures and not _has_coo_imp:
```
For the connectors of ScaleFreeBA, ScaleFreeBADual and PowerLaw, `build_mat` function has already implemented and there is no `build_coo` function, if we want to require `bp.connect.COO`, the judgment here is going to be correct and it's going to go down. So the logic here is wrong, just remove `not` is ok.
