### PR TITLE
Fix issue of https://github.com/brainpy/BrainPy/issues/455. The ``lambda _: 1`` needs a input.

### DIFF
--- a/brainpy/_src/math/object_transform/controls.py
+++ b/brainpy/_src/math/object_transform/controls.py
@@ -653,7 +653,7 @@ def ifelse(
                      f'Got len(conditions)={len(conditions)} and len(branches)={len(branches)}. '
                      f'We expect len(conditions) + 1 == len(branches). ')
   if operands is None:
-    operands = tuple()
+    operands = (tuple(),)
   if not isinstance(operands, (tuple, list)):
     operands = (operands,)
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Please do remember to follow the contributing guidelines -->

## Description
<!--- Why is this change required? What problem does it solve? -->

The ``lambda _: 1`` needs a input. By default, the input is ``operands=None``, then updated to tuple() by 
```python
if operands is None:
  operands = tuple()
```
However, even 
```python
func = lambda _:1
func(tuple())
```
works, BrainPy still gets an error as ``TypeError: <lambda>() missing 1 required positional argument: '_'``


<!--- Describe your changes in detail here to communicate to the maintainers why this pull request should be accepted -->

There are ways to fix this error, changing the default value of operands to be ``operands = 1`` or  ``operands = (1)`` etc, all works. But the same method in function cond(..., operands = ()) doesn't work either. It seems empty tuple or list cannot be recognized.

<!--- Describe your technology stack here if not a documentation update -->
<!--- Tasklist format is recommended for all pull requests and is required for all draft pull requests. You can couple your description with the tasklist -->
<!--- If it fixes an open issue, please link to the issue here in the last line. -->
Fix issue of https://github.com/brainpy/BrainPy/issues/455.
## How Has This Been Tested
<!--- Please describe in detail how you tested your changes locally -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- For example, markdown files should pass markdownlint locally according to the rules -->
<!--- See how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Only left the line that best describes this pull request -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Code follows the code style of this project.
- [ ] Changes follow the **CONTRIBUTING** guidelines.
- [ ] Update necessary documentation accordingly.
- [x] Lint and tests pass locally with the changes.
- [x] Check issues and pull requests first. You don't want to duplicate effort.

## Other information