### PR TITLE
[docs] add BrainPy docker and docs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ jobs:
           - context: "docker/"
             base: "brainpy/brainpy"
     env:
-      TARGET_PLATFORMS: linux/amd64,linux/arm64
+      TARGET_PLATFORMS: linux/amd64
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}
       DOCKER_TAG_NAME: |
@@ -39,12 +39,6 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
 
     - name: Docker Build & Push (version tag)
       uses: docker/build-push-action@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,65 @@
+name: Docker
+
+on:
+  release:
+    types: [published]
+  pull_request:
+    paths:
+      - docker/**
+      - .github/workflows/docker.yml
+
+
+jobs:
+  docker-build-push:
+    if: |
+        github.repository_owner == 'brainpy' ||
+        github.event_name != 'release'
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - context: "docker/"
+            base: "brainpy/brainpy"
+    env:
+      TARGET_PLATFORMS: linux/amd64,linux/arm64
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+      DOCKER_TAG_NAME: |
+        ${{
+          (github.event_name == 'release' && github.event.release.tag_name) ||
+          'pull-request-test'
+        }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Login to DockerHub
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Docker Build & Push (version tag)
+      uses: docker/build-push-action@v4
+      with:
+        context: ${{ matrix.context }}
+        tags: ${{ matrix.base }}:${{ env.DOCKER_TAG_NAME }}
+        push: ${{ github.event_name != 'pull_request' }}
+        platforms: ${{ env.TARGET_PLATFORMS }}
+
+    - name: Docker Build & Push (latest tag)
+      if: |
+          (github.event_name == 'release' && ! github.event.release.prerelease)
+      uses: docker/build-push-action@v4
+      with:
+        context: ${{ matrix.context }}
+        tags: ${{ matrix.base }}:latest
+        push: ${{ github.event_name != 'pull_request' }}
+        platforms: ${{ env.TARGET_PLATFORMS }}

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ docker pull brainpy/brainpy:latest
 
 Then, you can run the image with the following command:
 ```bash
-$ docker run -it brainpy/brainpy:latest
+$ docker run -it --platform linux/amd64 brainpy/brainpy:latest
 ```
 
 ### Using BrainPy with Binder

--- a/README.md
+++ b/README.md
@@ -34,6 +34,24 @@ $ pip install brainpy brainpylib -U
 For detailed installation instructions, please refer to the documentation: [Quickstart/Installation](https://brainpy.readthedocs.io/en/latest/quickstart/installation.html)
 
 
+### Using BrainPy with docker
+
+We provide a docker image for BrainPy. You can use the following command to pull the image:
+```bash
+$ docker pull brainpy/brainpy:latest
+```
+
+Then, you can run the image with the following command:
+```bash
+$ docker run -it brainpy/brainpy:latest
+```
+
+### Using BrainPy with Binder
+
+We provide a Binder environment for BrainPy. You can use the following button to launch the environment:
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/brainpy/BrainPy-binder/main)
+
 ## Ecosystem
 
 - **[BrainPy](https://github.com/brainpy/BrainPy)**: The solution for the general-purpose brain dynamics programming. 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:22.04
+
+ENV TZ=Asia/Dubai
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt update
+RUN apt install -y --no-install-recommends software-properties-common
+
+RUN apt update && apt install -y python3-pip
+
+RUN ln -sf /usr/bin/python3.10 /usr/bin/python && \
+    ln -sf /usr/bin/pip3 /usr/bin/pip
+
+
+RUN pip --no-cache-dir install --upgrade pip && \
+    pip --no-cache-dir install --upgrade setuptools && \
+    pip --no-cache-dir install --upgrade wheel
+
+ADD . /usr/src/app
+WORKDIR /usr/src/app
+
+RUN pip --no-cache-dir install --upgrade "jax[cpu]"
+RUN pip --no-cache-dir install --upgrade -r requirements.txt

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,0 +1,16 @@
+numpy
+tqdm
+msgpack
+matplotlib>=3.4
+jax
+jaxlib
+scipy>=1.1.0
+brainpy
+brainpylib
+brainpy_datasets
+h5py
+pathos
+
+# test requirements
+pytest
+absl-py

--- a/docs/quickstart/installation.rst
+++ b/docs/quickstart/installation.rst
@@ -225,13 +225,13 @@ If you want to use BrainPy in docker, you can use the following command to pull 
 
 .. code:: bash
 
-   docker pull brainpy/brainpy
+   docker pull brainpy/brainpy:latest
 
 You can then run the docker image by:
 
 .. code:: bash
 
-   docker run -it brainpy/brainpy
+   docker run -it --platform linux/amd64 brainpy/brainpy:latest
 
 Please notice that BrainPy docker image is based on the `ubuntu22.04` image, so it only support CPU version of BrainPy.
 

--- a/docs/quickstart/installation.rst
+++ b/docs/quickstart/installation.rst
@@ -197,33 +197,43 @@ Dependency 3: brainpylib
 ------------------------
 
 Many customized operators in BrainPy are implemented in ``brainpylib``.
-``brainpylib`` can also be installed from https://www.brainpylib/index.html according to your CUDA version.
+``brainpylib`` can also be installed from pypi according to your devices.
+For windows, Linux and MacOS users, ``brainpylib`` supports CPU operators.
+You can install CPU-version `brainpylib` by:
+
+.. code-block:: bash
+
+    # CPU installation
+    pip install --upgrade brainpylib
+
+For Nvidia GPU users, ``brainpylib`` only support Linux system and WSL2 subsystem. You can install the CUDA-version by using:
 
 .. code-block:: bash
 
     # CUDA 12 installation
-    pip install --upgrade "brainpylib[cuda12]" -f https://www.brainpylib/index.html
+    pip install --upgrade brainpylib-cu12x
 
 .. code-block:: bash
 
     # CUDA 11 installation
-    pip install --upgrade "brainpylib[cuda11]" -f https://www.brainpylib/index.html
+    pip install --upgrade brainpylib-cu11x
 
-For windows, Linux and MacOS users, ``brainpylib`` supports CPU operators.
-
-For CUDA users, ``brainpylib`` only support GPU on Linux platform. You can install GPU version ``brainpylib``
-on Linux through ``pip install brainpylib`` too.
-
-
-Installation from docker
+Running BrainPy with docker
 ------------------------
 
-If you want to use BrainPy in docker, you can use the following command
-to install BrainPy:
+If you want to use BrainPy in docker, you can use the following command to pull the docker image:
 
 .. code:: bash
 
-   docker pull ztqakita/brainpy
+   docker pull brainpy/brainpy
+
+You can then run the docker image by:
+
+.. code:: bash
+
+   docker run -it brainpy/brainpy
+
+Please notice that BrainPy docker image is based on the `ubuntu22.04` image, so it only support CPU version of BrainPy.
 
 
 Running BrainPy online with binder


### PR DESCRIPTION
- Add CPU-version BrainPy dockers with amd64 and arm64 support. 
- Add corresponding docs.
