### PR TITLE
[docs] Fix typo in docs

### DIFF
--- a/docs/core_concept/brainpy_dynamical_system.ipynb
+++ b/docs/core_concept/brainpy_dynamical_system.ipynb
@@ -124,7 +124,7 @@
     "We call `s` as shared arguments because they are same and shared for all nodes/layers. On the contrary, different nodes/layers have different input `x`.\n",
     "\n",
     "Here, it is necessary to explain the usage of ``bp.share``.\n",
-    "- ``bp.share.save( )``: The function saves shared arguments in the global context. User can save shared arguments in tow ways, for example, if user want to set the current time ``t=100``, the current time step ``dt=0.1``,the user can use ``bp.share.save(\"t\",100,\"dt\",0.1)`` or                      ``bp.share.save(t=100,dt=0.1)``.\n",
+    "- ``bp.share.save( )``: The function saves shared arguments in the global context. User can save shared arguments in two ways, for example, if user want to set the current time ``t=100``, the current time step ``dt=0.1``,the user can use ``bp.share.save(\"t\",100,\"dt\",0.1)`` or                      ``bp.share.save(t=100,dt=0.1)``.\n",
     "  \n",
     "- ``bp.share.load( )``: The function gets the shared data by the ``key``, for example, ``bp.share.load(\"t\")``.\n",
     "  \n",


### PR DESCRIPTION
Fix typo in `docs/core_concept/brainpy_dynamical_system.ipynb`