### PR TITLE
fix bugs in `truncated_normal`

### DIFF
--- a/brainpy/_src/math/random.py
+++ b/brainpy/_src/math/random.py
@@ -828,7 +828,8 @@ class RandomState(Variable):
     # Uniformly fill tensor with values from [l, u], then translate to
     # [2l-1, 2u-1].
     key = self.split_key() if key is None else _formalize_key(key)
-    out = jr.uniform(key, size, dtype, minval=2 * l - 1, maxval=2 * u - 1)
+    # add a small value to avoid inf values after lax.erf_inv
+    out = jr.uniform(key, size, dtype, minval=2 * l - 1 + 1e-7, maxval=2 * u - 1 - 1e-7)
 
     # Use inverse cdf transform for normal distribution to get truncated
     # standard normal


### PR DESCRIPTION
## Description
`truncated_normal` in `brainpy.math.random` calls `jr.uniform` to sample from a uniform distribution and then inverse the cdf to get truncated values. 

`jr.uniform` samples from a *closed* interval. When `lower` or `upper` takes inf values and when `jr.uniform` sampled an extreme value, the inverse cdf would have inf values, which result in underflow values after clipping.

Fix: subtract and add a small value to `minval` and `maxval` arguments of `jr.uniform`.

## How Has This Been Tested


## Types of changes
- Bug fix (non-breaking change which fixes an issue)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Code follows the code style of this project.
- [x] Changes follow the **CONTRIBUTING** guidelines.
- [x] Update necessary documentation accordingly.
- [x] Lint and tests pass locally with the changes.
- [x] Check issues and pull requests first. You don't want to duplicate effort.

## Other information