### PR TITLE
[ci] Fix windows pytest fatal exception

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -113,4 +113,4 @@ jobs:
       - name: Test with pytest
         run: |
           cd brainpy
-          pytest _src/
+          pytest _src/ -p no:faulthandler


### PR DESCRIPTION
> This is an effect of a change introduced with pytest 5.0.0. From the release notes:
>
> > \#5440: The faulthandler standard library module is now enabled by default to help users diagnose crashes in C modules.
> >
> > This functionality was provided by integrating the external pytest-faulthandler plugin into the core, so users should remove that plugin from their requirements if used.
> >
> > For more information see the docs: https://docs.pytest.org/en/stable/usage.html#fault-handler
>
> You can mute these errors as follows:
>
> ```py
> pytest -p no:faulthandler
> ```