### PR TITLE
[bug] Fix prograss bar is not displayed and updated as expected

### DIFF
--- a/brainpy/_src/integrators/runner.py
+++ b/brainpy/_src/integrators/runner.py
@@ -244,7 +244,7 @@ class IntegratorRunner(Runner):
 
     # progress bar
     if self.progress_bar:
-      jax.pure_callback(lambda *args: self._pbar.update(), ())
+      jax.debug.callback(lambda *args: self._pbar.update(), ())
 
     # return of function monitors
     shared = dict(t=t + self.dt, dt=self.dt, i=i)

--- a/brainpy/_src/math/object_transform/controls.py
+++ b/brainpy/_src/math/object_transform/controls.py
@@ -726,7 +726,7 @@ def _get_for_loop_transform(
       dyn_vars[k]._value = carry[k]
     results = body_fun(*x, **unroll_kwargs)
     if progress_bar:
-      jax.pure_callback(lambda *arg: bar.update(), ())
+      jax.debug.callback(lambda *args: bar.update(), ())
     return dyn_vars.dict_data(), results
 
   if remat:

--- a/brainpy/_src/math/random.py
+++ b/brainpy/_src/math/random.py
@@ -67,10 +67,9 @@ def _size2shape(size):
 
 
 def _check_shape(name, shape, *param_shapes):
-  shape = core.as_named_shape(shape)
   if param_shapes:
-    shape_ = lax.broadcast_shapes(shape.positional, *param_shapes)
-    if shape.positional != shape_:
+    shape_ = lax.broadcast_shapes(shape, *param_shapes)
+    if shape != shape_:
       msg = ("{} parameter shapes must be broadcast-compatible with shape "
              "argument, and the result of broadcasting the shapes must equal "
              "the shape argument, but got result {} for shape argument {}.")

--- a/brainpy/_src/runners.py
+++ b/brainpy/_src/runners.py
@@ -631,7 +631,7 @@ class DSRunner(Runner):
 
     # finally
     if self.progress_bar:
-      jax.pure_callback(lambda: self._pbar.update(), ())
+      jax.debug.callback(lambda *args: self._pbar.update(), ())
     # share.clear_shargs()
     clear_input(self.target)
 

--- a/brainpy/_src/train/offline.py
+++ b/brainpy/_src/train/offline.py
@@ -219,7 +219,7 @@ class OfflineTrainer(DSTrainer):
       targets = target_data[node.name]
       node.offline_fit(targets, fit_record)
       if self.progress_bar:
-        jax.pure_callback(lambda *args: self._pbar.update(), ())
+        jax.debug.callback(lambda *args: self._pbar.update(), ())
 
   def _step_func_monitor(self):
     res = dict()

--- a/brainpy/_src/train/online.py
+++ b/brainpy/_src/train/online.py
@@ -252,7 +252,7 @@ class OnlineTrainer(DSTrainer):
 
     # finally
     if self.progress_bar:
-      jax.pure_callback(lambda *arg: self._pbar.update(), ())
+      jax.debug.callback(lambda *args: self._pbar.update(), ())
     return out, monitors
 
   def _check_interface(self):


### PR DESCRIPTION
`jax.pure_callback()` may not work as expected for certain use cases, such as updating a progress bar, whereas `jax.debug.callback()`can be used effectively.

`jax.pure_callback()` is intended for pure functions without side effects. If JAX determines that the callback's result isn't used in the computation, it might optimize the callback call out, which means updates to a progress bar (a side effect) wouldn't occur.

`jax.debug.callback()`, on the other hand, does not assume the function is pure and always executes the callback as part of the computation. This consistency ensures that progress bar updates and other side effects happen reliably, even under JAX transformations like jit and vmap.

For more detail, see https://jax.readthedocs.io/en/latest/notebooks/external_callbacks.html