### PR TITLE
[doc] Correct the docstring of pre2post_event_sum

### DIFF
--- a/brainpy/_src/math/pre_syn_post.py
+++ b/brainpy/_src/math/pre_syn_post.py
@@ -56,7 +56,7 @@ def pre2post_event_sum(events,
     for i in range(pre_num):
       if events[i]:
         for j in range(idnptr[i], idnptr[i+1]):
-          post_val[post_ids[i]] += values
+          post_val[post_ids[j]] += values
 
   When ``values`` is a vector (with the length of ``len(post_ids)``),
   this function is equivalent to
@@ -70,7 +70,7 @@ def pre2post_event_sum(events,
     for i in range(pre_num):
       if events[i]:
         for j in range(idnptr[i], idnptr[i+1]):
-          post_val[post_ids[i]] += values[j]
+          post_val[post_ids[j]] += values[j]
 
 
   Parameters


### PR DESCRIPTION
This pull request includes changes to the `pre2post_event_sum` function in the `brainpy/_src/math/pre_syn_post.py` file to correct the indexing of `post_val` and ensure proper summation of values.

Corrections to indexing and summation:

* [`brainpy/_src/math/pre_syn_post.py`](diffhunk://#diff-ee5eaf5f703c06aee06b6cc3590ca686ba81472d1be9a174b1be2c116e481cc8L59-R59): Corrected the indexing of `post_val` from `post_ids[i]` to `post_ids[j]` to ensure that the correct post-synaptic values are updated.