### PR TITLE
[bug] Fix test bug

### DIFF
--- a/brainpy/_src/math/op_register/ad_support.py
+++ b/brainpy/_src/math/op_register/ad_support.py
@@ -43,7 +43,7 @@ def _standard_jvp(jvp_rules, primitive: Primitive, primals, tangents, **params):
       assert tree_util.tree_structure(r) == tree
   return val_out, functools.reduce(_add_tangents,
                                    tangents_out,
-                                   tree_util.tree_map(lambda a: ad.Zero.from_value(a), val_out))
+                                   tree_util.tree_map(lambda a: ad.Zero.from_primal_value(a), val_out))
 
 
 def _add_tangents(xs, ys):


### PR DESCRIPTION
This pull request includes a small but important change to the `brainpy/_src/math/op_register/ad_support.py` file. The change modifies how zero tangents are created from primal values in the `_standard_jvp` function.

* [`brainpy/_src/math/op_register/ad_support.py`](diffhunk://#diff-41c1e42a6317f685354a4edf87f781939f40f51c3fc223d0811ef3acfb80bed4L46-R46): Changed the lambda function to use `ad.Zero.from_primal_value` instead of `ad.Zero.from_value` when mapping over `val_out`.