### PR TITLE
[dependency] Remove unnecessary dependency

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,13 +20,7 @@ Installation
           # python 3.9-3.11
           pip install -U brainpy[cpu]  # windows, linux, macos
 
-    .. tab-item:: GPU (CUDA 11.0)
-
-       .. code-block:: bash
-
-          pip install -U brainpy[cuda11] -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-
-    .. tab-item:: GPU (CUDA 12.0)
+    .. tab-item:: GPU (CUDA 12)
 
        .. code-block:: bash
 

--- a/setup.py
+++ b/setup.py
@@ -68,12 +68,10 @@ setup(
     'https://storage.googleapis.com/jax-releases/jax_cuda_releases.html',
   ],
   extras_require={
-    'cpu': ['jaxlib>=0.4.13', 'brainpylib', 'numba', 'braintaichi'],
-    'cuda11': ['jaxlib[cuda11_pip]', 'brainpylib', 'numba', 'braintaichi'],
-    'cuda12': ['jaxlib[cuda12_pip]', 'brainpylib', 'numba', 'braintaichi'],
+    'cpu': ['jaxlib>=0.4.13', 'numba', 'braintaichi'],
+    'cuda12': ['jaxlib[cuda12_pip]', 'numba', 'braintaichi'],
     'tpu': ['jaxlib[tpu]', 'numba',],
     'cpu_mini': ['jaxlib>=0.4.13'],
-    'cuda11_mini': ['jaxlib[cuda11_pip]'],
     'cuda12_mini': ['jaxlib[cuda12_pip]'],
   },
   keywords=('computational neuroscience, '


### PR DESCRIPTION
This pull request includes changes to the installation instructions and dependencies for the `brainpy` package, specifically removing support for CUDA 11 and updating the documentation accordingly.

Updates to installation instructions and dependencies:

* [`docs/index.rst`](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534L23-R23): Removed the installation instructions for GPU with CUDA 11 and updated the tab label for CUDA 12.
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L71-L76): Removed the dependencies for CUDA 11 and adjusted the extras_require section to reflect this change.