### PR TITLE
[ci] Add ci support for python 3.12

### DIFF
--- a/.github/workflows/CI-models.yml
+++ b/.github/workflows/CI-models.yml
@@ -132,7 +132,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install numpy>=1.21.0
         python -m pip install -r requirements-dev.txt
-        python -m pip install tqdm brainpylib
+        python -m pip install tqdm
         pip uninstall brainpy -y
         python setup.py install
     - name: Test with pytest

--- a/.github/workflows/CI-models.yml
+++ b/.github/workflows/CI-models.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11"]
+        python-version: [ "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11"]
+        python-version: [ "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -119,7 +119,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
 
     steps:
       - name: Cancel Previous Runs
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
 
     steps:
       - name: Cancel Previous Runs
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
 
     steps:
       - name: Cancel Previous Runs

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ braintaichi
 numba
 brainstate
 braintools
+setuptools
 
 
 # test requirements


### PR DESCRIPTION
This pull request includes updates to the CI configuration files to add support for Python 3.12. The changes are made across multiple sections in two files: `.github/workflows/CI-models.yml` and `.github/workflows/CI.yml`.

Updates to CI configuration:

* [`.github/workflows/CI-models.yml`](diffhunk://#diff-92c106692b8ac80629dc2acd22fdc0ac5f445000eb97458e2b88b85b0a342833L25-R25): Added Python 3.12 to the `python-version` matrix in three different job strategies. [[1]](diffhunk://#diff-92c106692b8ac80629dc2acd22fdc0ac5f445000eb97458e2b88b85b0a342833L25-R25) [[2]](diffhunk://#diff-92c106692b8ac80629dc2acd22fdc0ac5f445000eb97458e2b88b85b0a342833L73-R73) [[3]](diffhunk://#diff-92c106692b8ac80629dc2acd22fdc0ac5f445000eb97458e2b88b85b0a342833L122-R122)
* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L31-R31): Added Python 3.12 to the `python-version` matrix in three different job strategies. [[1]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L31-R31) [[2]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L62-R62) [[3]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L95-R95)