### PR TITLE
[feat] Support `brainunit.Quantity` type `value` param in creating `Variable`

### DIFF
--- a/brainpy/_src/math/object_transform/tests/test_variable.py
+++ b/brainpy/_src/math/object_transform/tests/test_variable.py
@@ -1,9 +1,12 @@
 import brainpy.math as bm
+import brainunit as u
+import jax.numpy as jnp
+from functools import partial
 import unittest
 
 
 class TestVar(unittest.TestCase):
-  def test1(self):
+  def test_ndarray(self):
     class A(bm.BrainPyObject):
       def __init__(self):
         super().__init__()
@@ -33,6 +36,8 @@ class TestVar(unittest.TestCase):
 
     print()
     a = A()
+    temp = a.f1()
+    print(temp)
     self.assertTrue(bm.all(a.f1() == 2.))
     self.assertTrue(len(a.f1._dyn_vars) == 2)
     print(a.f2())
@@ -43,6 +48,50 @@ class TestVar(unittest.TestCase):
     print()
     self.assertTrue(bm.allclose(a.f3(), 4.))
     self.assertTrue(len(a.f3._dyn_vars) == 2)
+
+    bm.clear_buffer_memory()
+
+  def test_state(self):
+    class B(bm.BrainPyObject):
+      def __init__(self):
+        super().__init__()
+        self.a = bm.Variable([0.,] * u.mV)
+        self.f1 = bm.jit(self.f)
+        self.f2 = bm.jit(self.ff)
+        self.f3 = bm.jit(self.fff)
+
+      def f(self):
+        ones_fun = partial(u.math.ones,unit=u.mV)
+        b = self.tracing_variable('b', ones_fun, (1,))
+        self.a += (b * 2)
+        return self.a.value
+
+      def ff(self):
+        self.b += 1. * u.mV
+
+      def fff(self):
+        self.f()
+        self.ff()
+        self.b *= self.a.value.mantissa
+        return self.b.value
+
+    print()
+    f_jit = bm.jit(B().f)
+    f_jit()
+    self.assertTrue(len(f_jit._dyn_vars) == 2)
+
+    print()
+    b = B()
+    self.assertTrue(u.math.all(b.f1() == [2.,] * u.mV))
+    self.assertTrue(len(b.f1._dyn_vars) == 2)
+    print(b.f2())
+    self.assertTrue(len(b.f2._dyn_vars) == 1)
+
+    print()
+    b = B()
+    print()
+    self.assertTrue(u.math.allclose(b.f3(), 4. * u.mV))
+    self.assertTrue(len(b.f3._dyn_vars) == 2)
 
     bm.clear_buffer_memory()
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@ pathos
 braintaichi
 numba
 brainstate
+brainunit
 braintools
 setuptools
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
   author_email='chao.brain@qq.com',
   packages=packages,
   python_requires='>=3.9',
-  install_requires=['numpy>=1.15', 'jax>=0.4.13', 'tqdm'],
+  install_requires=['numpy>=1.15', 'jax>=0.4.13', 'tqdm', 'brainstate', 'brainunit'],
   url='https://github.com/brainpy/BrainPy',
   project_urls={
     "Bug Tracker": "https://github.com/brainpy/BrainPy/issues",


### PR DESCRIPTION
This pull request introduces several changes to the `brainpy` project, focusing on enhancing the `Variable` class and updating test cases. The most important changes include the addition of new dependencies, modifications to the `Variable` class to support a new `state_mode`, and updates to the test cases to reflect these changes.

### Enhancements to `Variable` class:

* [`brainpy/_src/math/object_transform/variables.py`](diffhunk://#diff-74a60800e5df47e1b457e6f3b827e1f290fad6d81839eeba2b6d0ca5dd8cacf9L223-R225): Modified the `Variable` class to inherit from `State` and added a `state_mode` parameter to the constructor. This allows the `Variable` class to handle `Quantity` types appropriately. [[1]](diffhunk://#diff-74a60800e5df47e1b457e6f3b827e1f290fad6d81839eeba2b6d0ca5dd8cacf9L223-R225) [[2]](diffhunk://#diff-74a60800e5df47e1b457e6f3b827e1f290fad6d81839eeba2b6d0ca5dd8cacf9L253-R256) [[3]](diffhunk://#diff-74a60800e5df47e1b457e6f3b827e1f290fad6d81839eeba2b6d0ca5dd8cacf9L262-R272)

### Updates to test cases:

* [`brainpy/_src/math/object_transform/tests/test_variable.py`](diffhunk://#diff-b05853767880d964f24d764d3d23126a2a7e41980fc989f65e1ee323471facd2R2-R9): Updated the test cases to import `brainunit` and `jax.numpy`, and added a new `test_state` method to test the new `state_mode` functionality of the `Variable` class. [[1]](diffhunk://#diff-b05853767880d964f24d764d3d23126a2a7e41980fc989f65e1ee323471facd2R2-R9) [[2]](diffhunk://#diff-b05853767880d964f24d764d3d23126a2a7e41980fc989f65e1ee323471facd2R54-R97)

### Dependency updates:

* [`requirements-dev.txt`](diffhunk://#diff-2b4945591edfeaa4cf4d3f155e66d4b43d1bda7a55d881d5cf3107f1b05abbbcR11): Added `brainunit` to the development requirements.
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L60-R60): Added `brainstate` and `brainunit` to the installation requirements.