### PR TITLE
[bug] Fix exception handling for missing braintaichi module in dependency check

### DIFF
--- a/brainpy/_src/dependency_check.py
+++ b/brainpy/_src/dependency_check.py
@@ -60,3 +60,7 @@ def import_braintaichi(error_if_not_found=True):
         else:
             braintaichi = None
     return braintaichi
+
+
+def raise_braintaichi_not_found():
+    raise ModuleNotFoundError(braintaichi_install_info)

--- a/brainpy/_src/dependency_check.py
+++ b/brainpy/_src/dependency_check.py
@@ -52,15 +52,11 @@ def import_braintaichi(error_if_not_found=True):
         if importlib.util.find_spec('braintaichi') is not None:
             try:
                 import braintaichi as braintaichi
-            except ModuleNotFoundError:
+            except ModuleNotFoundError as e:
                 if error_if_not_found:
-                    raise_braintaichi_not_found()
+                    raise e
                 else:
                     braintaichi = None
         else:
             braintaichi = None
     return braintaichi
-
-
-def raise_braintaichi_not_found():
-    raise ModuleNotFoundError(braintaichi_install_info)


### PR DESCRIPTION
This pull request simplifies error handling in the `import_braintaichi` function by removing an unnecessary helper function and directly raising the caught exception. 

Error handling improvements:

* [`brainpy/_src/dependency_check.py`](diffhunk://#diff-2165e9fbe8ca8446179163054210b26cc98aeae80f6c6063d91ce0fa0ffc7f11L55-L66): Removed the `raise_braintaichi_not_found` helper function and updated the `import_braintaichi` function to raise the caught `ModuleNotFoundError` directly with its original context. This change ensures that the original exception details are preserved for better debugging.