### PR TITLE
[bug] Fix order of return values in `__load_state__`

### DIFF
--- a/.github/workflows/CI-models.yml
+++ b/.github/workflows/CI-models.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12"]
+        python-version: [ "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12"]
+        python-version: [ "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -119,7 +119,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.10", "3.11", "3.12" ]
 
     steps:
       - name: Cancel Previous Runs
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.10", "3.11", "3.12" ]
 
     steps:
       - name: Cancel Previous Runs
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.10", "3.11", "3.12" ]
 
     steps:
       - name: Cancel Previous Runs

--- a/brainpy/_src/math/object_transform/base.py
+++ b/brainpy/_src/math/object_transform/base.py
@@ -517,7 +517,7 @@ class BrainPyObject(object):
       variables[key].value = jax.numpy.asarray(state_dict[key])
     unexpected_keys = list(keys1 - keys2)
     missing_keys = list(keys2 - keys1)
-    return unexpected_keys, missing_keys
+    return missing_keys, unexpected_keys
 
   def state_dict(self, **kwargs) -> dict:
     """Returns a dictionary containing a whole state of the module.

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
   author='BrainPy Team',
   author_email='chao.brain@qq.com',
   packages=packages,
-  python_requires='>=3.9',
+  python_requires='>=3.10',
   install_requires=['numpy>=1.15', 'jax>=0.4.13,<0.6.0', 'tqdm'],
   url='https://github.com/brainpy/BrainPy',
   project_urls={
@@ -84,7 +84,6 @@ setup(
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',


### PR DESCRIPTION
Closes #748 

This pull request includes a minor but important change to the `__load_state__` method in the `brainpy/_src/math/object_transform/base.py` file. The change swaps the order of the returned values, ensuring `missing_keys` is returned before `unexpected_keys`.

* [`brainpy/_src/math/object_transform/base.py`](diffhunk://#diff-04cd59832a1e69d7e6c69b966d046f4ea4251848a96abf7788b4e27a01f0287bL520-R520): Updated the `__load_state__` method to return `missing_keys` first, followed by `unexpected_keys`, aligning with expected conventions or use cases.