### PR TITLE
Add BrainPy citation and update documentation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,8 +50,7 @@ jobs:
           python setup.py install
       - name: Test with pytest
         run: |
-          cd brainpy
-          export IS_GITHUB_ACTIONS=1 && pytest _src/
+          pytest brainpy/_src/
 
 
   test_macos:
@@ -83,8 +82,7 @@ jobs:
 #          pip install jaxlib==0.4.30
       - name: Test with pytest
         run: |
-          cd brainpy
-          export IS_GITHUB_ACTIONS=1 && pytest _src/
+          pytest brainpy/_src/
 
 
   test_windows:
@@ -114,5 +112,4 @@ jobs:
           python setup.py install
       - name: Test with pytest
         run: |
-          cd brainpy
-          pytest _src/
+          pytest brainpy/_src/

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ BrainPy is a flexible, efficient, and extensible framework for computational neu
 - **Ecosystem**: https://brainmodeling.readthedocs.io/
 
 
-BrainPy now is rewritten based on [brainstate](https://github.com/chaobrain/brainstate), please learn [brainstate documentation](https://brainstate.readthedocs.io/) for the latest updates. 
+BrainPy is rewritten based on [brainstate](https://github.com/chaobrain/brainstate) since August 2025, please learn [brainstate documentation](https://brainstate.readthedocs.io/) for the latest updates. 
 
 
 ## Installation
@@ -57,11 +57,10 @@ We provide a Binder environment for BrainPy. You can use the following button to
 
 - **[BrainPy](https://github.com/brainpy/BrainPy)**: The solution for the general-purpose brain dynamics programming. 
 - **[brainpy-examples](https://github.com/brainpy/examples)**: Comprehensive examples of BrainPy computation. 
-- **[brainpy-datasets](https://github.com/brainpy/datasets)**: Neuromorphic and Cognitive Datasets for Brain Dynamics Modeling.
+- **[brain modeling ecosystem](https://brainmodeling.readthedocs.io/)**: A collection of tools and libraries for brain modeling and simulation.
 - [《神经计算建模实战》 (Neural Modeling in Action)](https://github.com/c-xy17/NeuralModeling)
 - [第一届神经计算建模与编程培训班 (First Training Course on Neural Modeling and Programming)](https://github.com/brainpy/1st-neural-modeling-and-programming-course)
 - [第二届神经计算建模与编程培训班 (Second Training Course on Neural Modeling and Programming)](https://github.com/brainpy/2nd-neural-modeling-and-programming-course)
-- **[brain modeling ecosystem](https://brainmodeling.readthedocs.io/)**: A collection of tools and libraries for brain modeling and simulation.
 
 
 ## Citing 
@@ -69,5 +68,27 @@ We provide a Binder environment for BrainPy. You can use the following button to
 BrainPy is developed by a team in Neural Information Processing Lab at Peking University, China. 
 Our team is committed to the long-term maintenance and development of the project. 
 
-If you are using ``brainpy``, please consider citing [the corresponding papers](https://brainpy.readthedocs.io/en/latest/tutorial_FAQs/citing_and_publication.html). 
+If you are using ``brainpy``, please consider citing the corresponding paper:
+
+```bibtex
+@article {10.7554/eLife.86365,
+    article_type = {journal},
+    title = {BrainPy, a flexible, integrative, efficient, and extensible framework for general-purpose brain dynamics programming},
+    author = {Wang, Chaoming and Zhang, Tianqiu and Chen, Xiaoyu and He, Sichao and Li, Shangyang and Wu, Si},
+    editor = {Stimberg, Marcel},
+    volume = 12,
+    year = 2023,
+    month = {dec},
+    pub_date = {2023-12-22},
+    pages = {e86365},
+    citation = {eLife 2023;12:e86365},
+    doi = {10.7554/eLife.86365},
+    url = {https://doi.org/10.7554/eLife.86365},
+    abstract = {Elucidating the intricate neural mechanisms underlying brain functions requires integrative brain dynamics modeling. To facilitate this process, it is crucial to develop a general-purpose programming framework that allows users to freely define neural models across multiple scales, efficiently simulate, train, and analyze model dynamics, and conveniently incorporate new modeling approaches. In response to this need, we present BrainPy. BrainPy leverages the advanced just-in-time (JIT) compilation capabilities of JAX and XLA to provide a powerful infrastructure tailored for brain dynamics programming. It offers an integrated platform for building, simulating, training, and analyzing brain dynamics models. Models defined in BrainPy can be JIT compiled into binary instructions for various devices, including Central Processing Unit (CPU), Graphics Processing Unit (GPU), and Tensor Processing Unit (TPU), which ensures high running performance comparable to native C or CUDA. Additionally, BrainPy features an extensible architecture that allows for easy expansion of new infrastructure, utilities, and machine-learning approaches. This flexibility enables researchers to incorporate cutting-edge techniques and adapt the framework to their specific needs},
+    journal = {eLife},
+    issn = {2050-084X},
+    publisher = {eLife Sciences Publications, Ltd},
+}
+```
+
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  	<img alt="Header image of BrainPy - brain dynamics programming in Python." src="https://github.com/brainpy/BrainPy/blob/master/images/logo.png" width=80%>
+  	<img alt="Header image of BrainPy - brain dynamics programming in Python." src="https://raw.githubusercontent.com/brainpy/BrainPy/master/images/logo.png" width=80%>
 </p> 
 
 
@@ -64,9 +64,6 @@ We provide a Binder environment for BrainPy. You can use the following button to
 
 
 ## Citing 
-
-BrainPy is developed by a team in Neural Information Processing Lab at Peking University, China. 
-Our team is committed to the long-term maintenance and development of the project. 
 
 If you are using ``brainpy``, please consider citing the corresponding paper:
 

--- a/brainpy/_src/measure/tests/test_correlation.py
+++ b/brainpy/_src/measure/tests/test_correlation.py
@@ -17,7 +17,7 @@ class TestCrossCorrelation(unittest.TestCase):
         bm.random.seed()
         spikes = bm.asarray([[1, 0, 1, 0, 1, 0, 1, 0, 0], [1, 1, 1, 1, 1, 1, 1, 0, 0]]).T
         cc1 = bp.measure.cross_correlation(spikes, 1., dt=1.)
-        f_cc = jit(partial(bp.measure.cross_correlation, numpy=False, bin=1, dt=1.))
+        f_cc = jit(partial(bp.measure.cross_correlation, bin=1, dt=1.))
         cc2 = f_cc(spikes)
         print(cc1, cc2)
         self.assertTrue(cc1 == cc2)
@@ -67,8 +67,8 @@ class TestVoltageFluctuation(unittest.TestCase):
         voltages = bm.ones((100, 10))
         r1 = bp.measure.voltage_fluctuation(voltages)
 
-        jit_f = jit(partial(bp.measure.voltage_fluctuation, numpy=False))
-        jit_f = jit(lambda a: bp.measure.voltage_fluctuation(a, numpy=False))
+        jit_f = jit(partial(bp.measure.voltage_fluctuation))
+        jit_f = jit(lambda a: bp.measure.voltage_fluctuation(a))
         r2 = jit_f(voltages)
         print(r1, r2)  # TODO: JIT results are different?
         # self.assertTrue(r1 == r2)
@@ -82,7 +82,7 @@ class TestFunctionalConnectivity(unittest.TestCase):
         act = bm.random.random((10000, 3))
         r1 = bp.measure.functional_connectivity(act)
 
-        jit_f = jit(partial(bp.measure.functional_connectivity, numpy=False))
+        jit_f = jit(partial(bp.measure.functional_connectivity))
         r2 = jit_f(act)
 
         self.assertTrue(bm.allclose(r1, r2))
@@ -95,6 +95,6 @@ class TestMatrixCorrelation(unittest.TestCase):
         B = bm.random.random((100, 100))
         r1 = (bp.measure.matrix_correlation(A, B))
 
-        jit_f = jit(partial(bp.measure.matrix_correlation, numpy=False))
+        jit_f = jit(bp.measure.matrix_correlation)
         r2 = jit_f(A, B)
         self.assertTrue(bm.allclose(r1, r2))

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,8 +4,7 @@ API Documentation
 .. toctree::
    :maxdepth: 1
 
-   apis/auto/brainpy-changelog.md
-   apis/auto/brainpylib-changelog.md
+
    apis/brainpy.rst
    apis/math.rst
    apis/dnn.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,17 @@ Installation
 
           pip install -U brainpy[tpu]
 
+    .. tab-item:: Ecosystem
+
+       .. code-block:: bash
+
+          pip install -U BrainX[cpu]
+          # or
+          pip install -U BrainX[cuda12]
+          # or
+          pip install -U BrainX[tpu]
+
+
 
 ----
 
@@ -93,7 +104,7 @@ Learn more
 
       .. card:: :material-regular:`settings;2em` Examples
          :class-card: sd-text-black sd-bg-light
-         :link: https://brainpy-examples.readthedocs.io/en/latest/index.html
+         :link: https://brainpy-examples.readthedocs.io/
 
    .. grid-item::
       :columns: 6 6 6 4
@@ -140,4 +151,5 @@ Learn more
    advanced_tutorials.rst
    FAQ.rst
    api.rst
-
+   apis/auto/brainpy-changelog.md
+   apis/auto/brainpylib-changelog.md

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,8 +36,10 @@ Installation
        .. code-block:: bash
 
           pip install -U BrainX[cpu]
+
           # or
           pip install -U BrainX[cuda12]
+
           # or
           pip install -U BrainX[tpu]
 
@@ -121,7 +123,7 @@ Learn more
 
 
 .. note::
-   BrainPy is rewritten based on `brainstate <https://github.com/chaobrain/brainstate>`_ since August 2025.
+   ``BrainPy>=3.0.0`` is rewritten based on `brainstate <https://github.com/chaobrain/brainstate>`_ since August 2025.
 
 
 

--- a/docs/quickstart/installation.rst
+++ b/docs/quickstart/installation.rst
@@ -20,29 +20,6 @@ To install brainpy with minimum requirements (has installed ``jax`` and ``jaxlib
     pip install brainpy
 
 
-Minimum requirements (with dependencies)
-----------------------------------------
-
-.. note::
-
-   Full features of brainpy currently is only available on Python 3.9 - 3.11.
-
-
-To install brainpy with minimum requirements (only depends on ``jax``), you can use:
-
-.. code-block:: bash
-
-    pip install brainpy[cpu_mini] # for CPU
-
-    # or
-
-    pip install brainpy[cuda12_mini] -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html  # for CUDA 12.0
-
-    # or
-
-    pip install brainpy[tpu] -f https://storage.googleapis.com/jax-releases/libtpu_releases.html  # for google TPU
-
-
 CPU with all dependencies
 -------------------------
 
@@ -51,6 +28,9 @@ To install a CPU-only version of BrainPy, which might be useful for doing local 
 .. code-block:: bash
 
     pip install brainpy[cpu]
+
+    pip install BrainX[cpu]  # for whole BrainX ecosystem
+
 
 
 
@@ -62,7 +42,10 @@ To install a GPU-only version of BrainPy, you can run
 
 .. code-block:: bash
 
-    pip install brainpy[cuda12] -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html  # for CUDA 12.0
+    pip install brainpy[cuda12] # for CUDA 12.0
+
+    pip install BrainX[cuda12]  # for whole BrainX ecosystem
+
 
 
 
@@ -74,6 +57,8 @@ you can run the following in your cloud TPU VM:
 
 .. code-block:: bash
 
-    pip install brainpy[tpu] -f https://storage.googleapis.com/jax-releases/libtpu_releases.html  # for google TPU
+    pip install brainpy[tpu]  # for google TPU
+
+    pip install BrainX[tpu]  # for whole BrainX ecosystem
 
 


### PR DESCRIPTION
This pull request includes updates to the `README.md` and documentation files to improve clarity, provide updated references, and enhance usability. The most important changes include updating references to BrainPy's ecosystem and documentation, adding citation details for the BrainPy framework, and reorganizing the API documentation structure.

### Updates to `README.md`:

* Updated the description of BrainPy's foundation to specify that it has been rewritten based on `brainstate` since August 2025.
* Replaced the outdated link to `brainpy-datasets` with a more general reference to the "brain modeling ecosystem."
* Added a detailed BibTeX citation for BrainPy, including publication details in the journal eLife, for users to reference the framework in academic work.

### Documentation improvements:

* Removed changelog links (`brainpy-changelog.md` and `brainpylib-changelog.md`) from the `docs/api.rst` file, likely to streamline the API documentation.
* Added an "Ecosystem" installation tab in `docs/index.rst` with commands for installing `BrainX` on different platforms (CPU, CUDA, TPU).
* Updated the "Learn more" section in `docs/index.rst` to include changelog links and fixed an outdated example link. [[1]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534L96-R107) [[2]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534L143-R155)

## Summary by Sourcery

Enhance README and documentation by updating BrainPy references, adding citation details, and improving the ecosystem installation and API docs structure

New Features:
- Add detailed BibTeX citation for the BrainPy framework in README.md
- Introduce an "Ecosystem" installation tab with CPU, CUDA, and TPU commands in docs/index.rst

Enhancements:
- Update README to specify rewriting based on brainstate since August 2025
- Replace the brainpy-datasets link with a generic brain modeling ecosystem reference

Documentation:
- Remove obsolete changelog links from docs/api.rst
- Update "Learn more" section in docs/index.rst with corrected example and changelog links