### PR TITLE
Downgrade version to 2.7.0 in __init__.py

### DIFF
--- a/brainpy/__init__.py
+++ b/brainpy/__init__.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 # ==============================================================================
 
-__version__ = "3.0.1"
-__version_info__ = (3, 0, 1)
+__version__ = "2.7.0"
+__version_info__ = (2, 7, 0)
 
 
 from brainpy import _errors as errors


### PR DESCRIPTION
Reverts the package version from 3.0.1 to 2.7.0 in brainpy/__init__.py, possibly to match a previous release or resolve compatibility issues.

## Summary by Sourcery

Chores:
- Downgrade __version__ to 2.7.0 in brainpy/__init__.py