### PR TITLE
Add typing for core utils, enable PEP 561, add mypy CI

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,49 @@
+# Static type-checking with mypy.
+#
+# This runs mypy over a curated, strictly-typed subset of BrainPy (configured via
+# ``[tool.mypy]`` in pyproject.toml). The curated set is fully annotated and checked
+# under strict rules; the rest of the (large, JAX-based) code base is resolved
+# silently so it neither blocks nor pollutes the check. Grow the curated set in
+# pyproject.toml as more modules become fully typed.
+
+name: Type Checking
+
+on:
+  push:
+    branches:
+      - '**'        # matches every branch
+  pull_request:
+    branches:
+      - '**'        # matches every branch
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ "3.13" ]
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install type-checking dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # mypy plus the only typed runtime dependency the curated modules touch.
+          # Heavy deps (jax, brainstate, ...) are intentionally not installed:
+          # `ignore_missing_imports`/`follow_imports = silent` handle them.
+          pip install mypy numpy
+      - name: Run mypy (curated strict subset)
+        run: |
+          mypy

--- a/brainpy/_errors.py
+++ b/brainpy/_errors.py
@@ -14,6 +14,7 @@
 
 # -*- coding: utf-8 -*-
 
+from typing import Any
 
 __all__ = [
     'BrainPyError',
@@ -79,7 +80,7 @@ class PackageMissingError(BrainPyError):
     __module__ = 'brainpy'
 
     @classmethod
-    def by_purpose(cls, name, purpose):
+    def by_purpose(cls, name: str, purpose: str) -> "PackageMissingError":
         err = (f'"{name}" must be installed when the user wants to use {purpose}. \n'
                f'Please install through "pip install {name}".')
         return cls(err)
@@ -88,7 +89,7 @@ class PackageMissingError(BrainPyError):
 class BackendNotInstalled(BrainPyError):
     __module__ = 'brainpy'
 
-    def __init__(self, backend):
+    def __init__(self, backend: str) -> None:
         super(BackendNotInstalled, self).__init__(
             '"{bk}" must be installed when the user wants to use {bk} backend. \n'
             'Please install {bk} through "pip install {bk}" '
@@ -98,7 +99,7 @@ class BackendNotInstalled(BrainPyError):
 class UniqueNameError(BrainPyError):
     __module__ = 'brainpy'
 
-    def __init__(self, *args):
+    def __init__(self, *args: Any) -> None:
         super(UniqueNameError, self).__init__(*args)
 
 
@@ -130,7 +131,7 @@ class MathError(BrainPyError):
 class JaxTracerError(MathError):
     __module__ = 'brainpy'
 
-    def __init__(self, variables=None):
+    def __init__(self, variables: Any = None) -> None:
         msg = 'There is an unexpected tracer. \n\n' \
               'In BrainPy, all the dynamically changed variables must be declared as ' \
               '"brainpy.math.Variable" and they should be provided ' \
@@ -159,7 +160,7 @@ class JaxTracerError(MathError):
 class GPUOperatorNotFound(Exception):
     __module__ = 'brainpy'
 
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         super(GPUOperatorNotFound, self).__init__(f'''
 GPU operator for "{name}" does not found. 
 

--- a/brainpy/tools/codes.py
+++ b/brainpy/tools/codes.py
@@ -16,8 +16,11 @@
 import inspect
 import re
 from types import LambdaType
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, TypeVar, cast
 
-BrainPyObject = None
+BrainPyObject: Any = None
+
+_F = TypeVar('_F', bound=Callable[..., Any])
 
 __all__ = [
     'repr_dict',
@@ -40,12 +43,12 @@ __all__ = [
 ]
 
 
-def repr_dict(dict_obj: dict):
+def repr_dict(dict_obj: Dict[Any, Any]) -> str:
     ret = [f'{k}={v}' for k, v in dict_obj.items()]
     return ', '.join(ret)
 
 
-def repr_object(x):
+def repr_object(x: Any) -> str:
     global BrainPyObject
     if BrainPyObject is None:
         from brainpy.math import BrainPyObject
@@ -53,39 +56,46 @@ def repr_object(x):
         return repr(x)
     elif callable(x):
         signature = inspect.signature(x)
-        args = [f'{k}={v.default}' for k, v in signature.parameters.items()
-                if v.default is not inspect.Parameter.empty]
-        args = ', '.join(args)
+        args = ', '.join([f'{k}={v.default}' for k, v in signature.parameters.items()
+                          if v.default is not inspect.Parameter.empty])
         while not hasattr(x, '__name__'):
             if not hasattr(x, 'func'):
                 break
             x = x.func  # Handle functools.partial
         if not hasattr(x, '__name__') and hasattr(x, '__class__'):
-            return x.__class__.__name__
+            cls_name: str = x.__class__.__name__
+            return cls_name
         if args:
             return f'{x.__name__}(*, {args})'
-        return x.__name__
+        name: str = x.__name__
+        return name
     else:
-        x = repr(x).split('\n')
-        x = [x[0]] + ['  ' + y for y in x[1:]]
-        return '\n'.join(x)
+        lines = repr(x).split('\n')
+        lines = [lines[0]] + ['  ' + y for y in lines[1:]]
+        return '\n'.join(lines)
 
 
-def repr_context(repr_str, indent):
+def repr_context(repr_str: str, indent: str) -> str:
     splits = repr_str.split('\n')
     splits = [(s if i == 0 else (indent + s)) for i, s in enumerate(splits)]
     return '\n'.join(splits)
 
 
-def copy_doc(source_f):
-    def copy(target_f):
+def copy_doc(source_f: Callable[..., Any]) -> Callable[[_F], _F]:
+    def copy(target_f: _F) -> _F:
         target_f.__doc__ = source_f.__doc__
         return target_f
 
     return copy
 
 
-def code_lines_to_func(lines, func_name, func_args, scope, remind=''):
+def code_lines_to_func(
+    lines: Sequence[str],
+    func_name: str,
+    func_args: Sequence[str],
+    scope: Dict[str, Any],
+    remind: str = '',
+) -> Tuple[str, Callable[..., Any]]:
     lines_for_compile = [f'    {line}' for line in lines]
     code_for_compile = '\n'.join(lines_for_compile)
     code = f'def {func_name}({", ".join(func_args)}):\n' + \
@@ -112,7 +122,7 @@ def code_lines_to_func(lines, func_name, func_args, scope, remind=''):
 ######################################
 
 
-def get_identifiers(expr, include_numbers=False):
+def get_identifiers(expr: str, include_numbers: bool = False) -> Set[str]:
     """
     Return all the identifiers in a given string ``expr``, that is everything
     that matches a programming language variable like expression, which is
@@ -153,7 +163,7 @@ def get_identifiers(expr, include_numbers=False):
     return (identifiers - _ID_KEYWORDS) | numbers
 
 
-def indent(text, num_tabs=1, spaces_per_tab=4, tab=None):
+def indent(text: str, num_tabs: int = 1, spaces_per_tab: int = 4, tab: Optional[str] = None) -> str:
     if tab is None:
         tab = ' ' * spaces_per_tab
     indent_ = tab * num_tabs
@@ -161,7 +171,7 @@ def indent(text, num_tabs=1, spaces_per_tab=4, tab=None):
     return indented_string
 
 
-def deindent(text, num_tabs=None, spaces_per_tab=4, docstring=False):
+def deindent(text: str, num_tabs: Optional[int] = None, spaces_per_tab: int = 4, docstring: bool = False) -> str:
     text = text.replace('\t', ' ' * spaces_per_tab)
     lines = text.split('\n')
     # if it's a docstring, we search for the common tabulation starting from
@@ -186,7 +196,7 @@ def deindent(text, num_tabs=None, spaces_per_tab=4, docstring=False):
     return '\n'.join(lines)
 
 
-def word_replace(expr, substitutions, exclude_dot=True):
+def word_replace(expr: str, substitutions: Dict[str, Any], exclude_dot: bool = True) -> str:
     """Applies a dict of word substitutions.
 
     The dict ``substitutions`` consists of pairs ``(word, rep)`` where each
@@ -212,12 +222,12 @@ def word_replace(expr, substitutions, exclude_dot=True):
 ######################################
 
 
-def change_func_name(f, name):
+def change_func_name(f: _F, name: str) -> _F:
     f.__name__ = name
     return f
 
 
-def is_lambda_function(func):
+def is_lambda_function(func: Any) -> bool:
     """Check whether the function is a ``lambda`` function. Comes from
     https://stackoverflow.com/questions/23852423/how-to-check-that-variable-is-a-lambda-function
 
@@ -234,7 +244,7 @@ def is_lambda_function(func):
     return isinstance(func, LambdaType) and func.__name__ == "<lambda>"
 
 
-def get_func_source(func):
+def get_func_source(func: Callable[..., Any]) -> str:
     code = inspect.getsource(func)
     # remove @
     try:
@@ -245,7 +255,7 @@ def get_func_source(func):
     return code
 
 
-def get_main_code(func, codes=None):
+def get_main_code(func: Optional[Callable[..., Any]], codes: Optional[str] = None) -> str:
     """Get the main function _code string.
 
     For lambda function, return the
@@ -261,23 +271,23 @@ def get_main_code(func, codes=None):
         return ''
     elif callable(func):
         if is_lambda_function(func):
-            codes = (codes or get_func_source(func))
-            splits = codes.split(':')
+            source = (codes or get_func_source(func))
+            splits = source.split(':')
             if len(splits) != 2:
-                raise ValueError(f'Can not parse function: \n{codes}')
+                raise ValueError(f'Can not parse function: \n{source}')
             return f'return {splits[1]}'
 
         else:
-            codes = (codes.split('\n') or inspect.getsourcelines(func)[0])
+            lines: List[str] = cast(str, codes).split('\n') or inspect.getsourcelines(func)[0]
             idx = 0
-            for line in codes:
+            for line in lines:
                 idx += 1
                 line = line.replace(' ', '')
                 if '):' in line:
                     break
             else:
-                code = "\n".join(codes)
+                code = "\n".join(lines)
                 raise ValueError(f'Can not parse function: \n{code}')
-            return ''.join(codes[idx:])
+            return ''.join(lines[idx:])
     else:
         raise ValueError(f'Unknown function type: {type(func)}.')

--- a/brainpy/tools/dicts.py
+++ b/brainpy/tools/dicts.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Union, Dict, Sequence
+from typing import Any, Dict, Mapping, Sequence, Union
 
 import numpy as np
 from brainstate._compatible_import import safe_zip
@@ -24,7 +24,7 @@ __all__ = [
 ]
 
 
-class DotDict(dict):
+class DotDict(Dict[str, Any]):
     """Python dictionaries with advanced dot notation access.
 
     For example:
@@ -56,23 +56,23 @@ class DotDict(dict):
 
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.__dict__ = self
 
     def copy(self) -> 'DotDict':
         return type(self)(super().copy())
 
-    def to_numpy(self):
+    def to_numpy(self) -> None:
         """Change all values to numpy arrays."""
         for key in tuple(self.keys()):
             self[key] = np.asarray(self[key])
 
-    def update(self, *args, **kwargs):
+    def update(self, *args: Any, **kwargs: Any) -> 'DotDict':  # type: ignore[override]  # returns self for chaining
         super().update(*args, **kwargs)
         return self
 
-    def __add__(self, other):
+    def __add__(self, other: Mapping[Any, Any]) -> 'DotDict':
         """Merging two dicts.
 
         Parameters::
@@ -89,7 +89,7 @@ class DotDict(dict):
         gather.update(other)
         return gather
 
-    def __sub__(self, other: Union[Dict, Sequence]):
+    def __sub__(self, other: Union[Dict[Any, Any], Sequence[Any]]) -> 'DotDict':
         """Remove other item in the collector.
 
         Parameters::
@@ -116,14 +116,14 @@ class DotDict(dict):
                     raise ValueError(f'Cannot remove {key}, because we do not find it '
                                      f'in {self.keys()}.')
         elif isinstance(other, (list, tuple)):
-            id_to_keys = {}
+            id_to_keys: Dict[int, list[Any]] = {}
             for k, v in self.items():
                 id_ = id(v)
                 if id_ not in id_to_keys:
                     id_to_keys[id_] = []
                 id_to_keys[id_].append(k)
 
-            keys_to_remove = []
+            keys_to_remove: list[Any] = []
             for key in other:
                 if isinstance(key, str):
                     keys_to_remove.append(key)
@@ -140,7 +140,7 @@ class DotDict(dict):
             raise KeyError(f'Unknown type of "other". Only support dict/tuple/list, but we got {type(other)}')
         return gather
 
-    def subset(self, var_type):
+    def subset(self, var_type: type) -> 'DotDict':
         """Get the subset of the (key, value) pair.
 
         ``subset()`` can be used to get a subset of some class:
@@ -171,7 +171,7 @@ class DotDict(dict):
                 gather[key] = value
         return gather
 
-    def unique(self):
+    def unique(self) -> 'DotDict':
         """Get a new type of collector with unique values.
 
         If one value is assigned to two or more keys,
@@ -185,7 +185,7 @@ class DotDict(dict):
                 gather[k] = v
         return gather
 
-    def __hash__(self):
+    def __hash__(self) -> int:  # type: ignore[override]  # dict sets __hash__ = None; DotDict is hashable
         return hash(tuple(sorted(self.items())))
 
 

--- a/brainpy/tools/functions.py
+++ b/brainpy/tools/functions.py
@@ -16,13 +16,16 @@ import inspect
 from functools import partial
 from operator import attrgetter
 from types import MethodType
+from typing import Any, Callable, Optional, Sequence, Tuple, TypeVar
 
 __all__ = [
     'compose', 'pipe'
 ]
 
+_T = TypeVar('_T')
 
-def identity(x):
+
+def identity(x: _T) -> _T:
     """ Identity function. Return x
 
     >>> identity(3)
@@ -31,7 +34,13 @@ def identity(x):
     return x
 
 
-def instanceproperty(fget=None, fset=None, fdel=None, doc=None, classval=None):
+def instanceproperty(
+    fget: Optional[Callable[..., Any]] = None,
+    fset: Optional[Callable[..., Any]] = None,
+    fdel: Optional[Callable[..., Any]] = None,
+    doc: Optional[str] = None,
+    classval: Any = None,
+) -> Any:
     """ Like @property, but returns ``classval`` when used as a class attribute
 
     >>> class MyClass(object):
@@ -66,17 +75,20 @@ class InstanceProperty(property):
     Should not be used directly.  Use ``instanceproperty`` instead.
     """
 
-    def __init__(self, fget=None, fset=None, fdel=None, doc=None,
-                 classval=None):
+    def __init__(self, fget: Optional[Callable[..., Any]] = None,
+                 fset: Optional[Callable[..., Any]] = None,
+                 fdel: Optional[Callable[..., Any]] = None,
+                 doc: Optional[str] = None,
+                 classval: Any = None) -> None:
         self.classval = classval
         property.__init__(self, fget=fget, fset=fset, fdel=fdel, doc=doc)
 
-    def __get__(self, obj, type=None):
+    def __get__(self, obj: Any, type: Any = None) -> Any:
         if obj is None:
             return self.classval
         return property.__get__(self, obj, type)
 
-    def __reduce__(self):
+    def __reduce__(self) -> Tuple[Any, ...]:
         state = (self.fget, self.fset, self.fdel, self.__doc__, self.classval)
         return InstanceProperty, state
 
@@ -89,26 +101,29 @@ class Compose(object):
     """
     __slots__ = 'first', 'funcs'
 
-    def __init__(self, funcs):
+    first: Callable[..., Any]
+    funcs: Tuple[Callable[..., Any], ...]
+
+    def __init__(self, funcs: Sequence[Callable[..., Any]]) -> None:
         funcs = tuple(reversed(funcs))
         self.first = funcs[0]
-        self.funcs = funcs[1:]
+        self.funcs = tuple(funcs[1:])
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
         ret = self.first(*args, **kwargs)
         for f in self.funcs:
             ret = f(ret)
         return ret
 
-    def __getstate__(self):
+    def __getstate__(self) -> Tuple[Any, ...]:
         return self.first, self.funcs
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: Tuple[Any, ...]) -> None:
         self.first, self.funcs = state
 
-    @instanceproperty(classval=__doc__)
-    def __doc__(self):
-        def composed_doc(*fs):
+    @instanceproperty(classval=__doc__)  # type: ignore[untyped-decorator]  # dynamic descriptor factory
+    def __doc__(self) -> str:
+        def composed_doc(*fs: Any) -> str:
             """Generate a docstring for the composition of fs.
             """
             if not fs:
@@ -127,40 +142,42 @@ class Compose(object):
             return 'A composition of functions'
 
     @property
-    def __name__(self):
+    def __name__(self) -> str:
         try:
             return '_of_'.join(
                 (f.__name__ for f in reversed((self.first,) + self.funcs))
             )
         except AttributeError:
-            return type(self).__name__
+            # ``type.__name__`` (metaclass descriptor) wins at runtime over the
+            # ``__name__`` property defined on this class.
+            return type(self).__name__  # type: ignore[return-value]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '{.__class__.__name__}{!r}'.format(
             self, tuple(reversed((self.first,) + self.funcs)))
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Compose):
             return other.first == self.first and other.funcs == self.funcs
         return NotImplemented
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         equality = self.__eq__(other)
         return NotImplemented if equality is NotImplemented else not equality
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.first) ^ hash(self.funcs)
 
     # Mimic the descriptor behavior of python functions.
     # i.e. let Compose be called as a method when bound to a class.
     # adapted from
     # docs.python.org/3/howto/descriptor.html#functions-and-methods
-    def __get__(self, obj, objtype=None):
+    def __get__(self, obj: Any, objtype: Any = None) -> Any:
         return self if obj is None else MethodType(self, obj)
 
     # introspection with Signature is only possible from py3.3+
     @instanceproperty
-    def __signature__(self):
+    def __signature__(self) -> inspect.Signature:
         base = inspect.signature(self.first)
         last = inspect.signature(self.funcs[-1])
         return base.replace(return_annotation=last.return_annotation)
@@ -168,7 +185,7 @@ class Compose(object):
     __wrapped__ = instanceproperty(attrgetter('first'))
 
 
-def compose(*funcs):
+def compose(*funcs: Callable[..., Any]) -> Callable[..., Any]:
     """ Compose functions to operate in series.
 
     Returns a function that applies other functions in sequence.
@@ -190,7 +207,7 @@ def compose(*funcs):
         return Compose(funcs)
 
 
-def pipe(*funcs):
+def pipe(*funcs: Callable[..., Any]) -> Callable[..., Any]:
     """ Pipe a value through a sequence of functions
 
     I.e. ``pipe(f, g, h)(data)`` is equivalent to ``h(g(f(data)))``

--- a/brainpy/tools/install.py
+++ b/brainpy/tools/install.py
@@ -16,7 +16,7 @@ __all__ = [
     'jaxlib_install_info',
 ]
 
-jaxlib_install_info = '''
+jaxlib_install_info: str = '''
 
 BrainPy needs jaxlib, please install it. 
 

--- a/brainpy/tools/math_util.py
+++ b/brainpy/tools/math_util.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from typing import Optional
+
 import numpy as np
 
 __all__ = [
@@ -20,10 +22,10 @@ __all__ = [
 ]
 
 
-def format_seed(seed=None):
+def format_seed(seed: Optional[int] = None) -> int:
     """Get the random sed.
     """
     if seed is None:
-        return np.random.randint(0, int(1e7))
+        return int(np.random.randint(0, int(1e7)))
     else:
         return seed

--- a/brainpy/tools/others.py
+++ b/brainpy/tools/others.py
@@ -16,7 +16,7 @@
 import _thread as thread
 import collections.abc
 import threading
-from typing import Optional, Tuple, Callable, Union, Sequence, TypeVar, Any, cast
+from typing import Optional, Tuple, Callable, Union, Sequence, TypeVar, Any
 
 import numpy as np
 
@@ -85,7 +85,7 @@ def not_customized(fun: Callable[..., Any]) -> Callable[..., Any]:
 
 def size2num(size: Union[int, Sequence[int]]) -> int:
     if isinstance(size, (int, np.integer)):
-        return cast(int, size)
+        return size
     elif isinstance(size, (tuple, list)):
         a = 1
         for b in size:
@@ -99,7 +99,7 @@ def to_size(x: Union[int, Sequence[int], None]) -> Optional[Tuple[int, ...]]:
     if isinstance(x, (tuple, list)):
         return tuple(x)
     if isinstance(x, (int, np.integer)):
-        return (cast(int, x),)
+        return (x,)
     if x is None:
         return x
     raise ValueError(f'Cannot make a size for {x}')

--- a/brainpy/tools/others.py
+++ b/brainpy/tools/others.py
@@ -16,7 +16,7 @@
 import _thread as thread
 import collections.abc
 import threading
-from typing import Optional, Tuple, Callable, Union, Sequence, TypeVar, Any
+from typing import Optional, Tuple, Callable, Union, Sequence, TypeVar, Any, cast
 
 import numpy as np
 
@@ -30,7 +30,7 @@ __all__ = [
 ]
 
 
-def one_of(default: Any, *choices, names: Sequence[str] = None):
+def one_of(default: Any, *choices: Any, names: Optional[Sequence[str]] = None) -> Any:
     names = [f'arg{i}' for i in range(len(choices))] if names is None else names
     res = default
     has_chosen = False
@@ -56,7 +56,7 @@ def replicate(
     if isinstance(element, (str, bytes)) or not isinstance(element, collections.abc.Sequence):
         return (element,) * num_replicate
     elif len(element) == 1:
-        return tuple(element * num_replicate)
+        return tuple(element) * num_replicate
     elif len(element) == num_replicate:
         return tuple(element)
     else:
@@ -64,7 +64,7 @@ def replicate(
                         f"sequence of length {num_replicate}.")
 
 
-def not_customized(fun: Callable) -> Callable:
+def not_customized(fun: Callable[..., Any]) -> Callable[..., Any]:
     """Marks the given module method is not implemented.
 
     Methods wrapped in @not_customized can define submodules directly within the method.
@@ -79,13 +79,13 @@ def not_customized(fun: Callable) -> Callable:
       def feedback(self):
         ...
     """
-    fun.not_customized = True
+    fun.not_customized = True  # type: ignore[attr-defined]  # marker attribute on a callable
     return fun
 
 
-def size2num(size):
+def size2num(size: Union[int, Sequence[int]]) -> int:
     if isinstance(size, (int, np.integer)):
-        return size
+        return cast(int, size)
     elif isinstance(size, (tuple, list)):
         a = 1
         for b in size:
@@ -95,17 +95,17 @@ def size2num(size):
         raise ValueError(f'Do not support type {type(size)}: {size}')
 
 
-def to_size(x) -> Optional[Tuple[int]]:
+def to_size(x: Union[int, Sequence[int], None]) -> Optional[Tuple[int, ...]]:
     if isinstance(x, (tuple, list)):
         return tuple(x)
     if isinstance(x, (int, np.integer)):
-        return (x,)
+        return (cast(int, x),)
     if x is None:
         return x
     raise ValueError(f'Cannot make a size for {x}')
 
 
-def timeout(s):
+def timeout(s: float) -> Callable[[Callable[..., T]], Callable[..., T]]:
     """Add a timeout parameter to a function and return it.
 
     Parameters::
@@ -119,8 +119,8 @@ def timeout(s):
         Functional results. Or, raise an error of KeyboardInterrupt.
     """
 
-    def outer(fn):
-        def inner(*args, **kwargs):
+    def outer(fn: Callable[..., T]) -> Callable[..., T]:
+        def inner(*args: Any, **kwargs: Any) -> T:
             timer = threading.Timer(s, thread.interrupt_main)
             timer.start()
             try:

--- a/brainpy/tools/package.py
+++ b/brainpy/tools/package.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from typing import Any, Callable, Optional
+
 import numpy as np
 
 try:
@@ -27,27 +29,28 @@ __all__ = [
     'SUPPORT_NUMBA',
 ]
 
-SUPPORT_NUMBA = numba is not None
+SUPPORT_NUMBA: bool = numba is not None
 
 
-def numba_jit(f=None, **kwargs):
+def numba_jit(f: Optional[Callable[..., Any]] = None, **kwargs: Any) -> Callable[..., Any]:
     if f is None:
         return lambda f: (f if (numba is None) else numba.njit(f, **kwargs))
     else:
         if numba is None:
             return f
         else:
-            return numba.njit(f)
+            jitted: Callable[..., Any] = numba.njit(f)
+            return jitted
 
 
 @numba_jit
-def _seed(seed):
+def _seed(seed: int) -> None:
     np.random.seed(seed)
 
 
-def numba_seed(seed):
+def numba_seed(seed: Optional[int]) -> None:
     if numba is not None and seed is not None:
         _seed(seed)
 
 
-numba_range = numba.prange if SUPPORT_NUMBA else range
+numba_range: Callable[..., Any] = numba.prange if SUPPORT_NUMBA else range

--- a/brainpy/tools/progress.py
+++ b/brainpy/tools/progress.py
@@ -23,6 +23,7 @@ import re
 import sys
 import time
 import types as python_types
+from typing import Any, Callable, Container, Dict, Iterable, List, Optional, Sequence, Tuple, cast
 
 import numpy as np
 
@@ -30,7 +31,7 @@ import numpy as np
 # isort: off
 
 
-def func_dump(func):
+def func_dump(func: python_types.FunctionType) -> Tuple[str, Optional[Tuple[Any, ...]], Optional[Tuple[Any, ...]]]:
     """Serializes a user defined function.
 
     Args:
@@ -53,7 +54,8 @@ def func_dump(func):
     return code, defaults, closure
 
 
-def func_load(code, defaults=None, closure=None, globs=None):
+def func_load(code: Any, defaults: Any = None, closure: Any = None,
+              globs: Optional[Dict[str, Any]] = None) -> python_types.FunctionType:
     """Deserializes a user defined function.
 
     Args:
@@ -70,7 +72,7 @@ def func_load(code, defaults=None, closure=None, globs=None):
         if isinstance(defaults, list):
             defaults = tuple(defaults)
 
-    def ensure_value_to_cell(value):
+    def ensure_value_to_cell(value: Any) -> Any:
         """Ensures that a value is converted to a python cell object.
 
         Args:
@@ -80,10 +82,10 @@ def func_load(code, defaults=None, closure=None, globs=None):
             A value wrapped as a cell object (see function "func_load")
         """
 
-        def dummy_fn():
+        def dummy_fn() -> None:
             value  # just access it so it gets captured in .__closure__
 
-        cell_value = dummy_fn.__closure__[0]
+        cell_value = dummy_fn.__closure__[0]  # type: ignore[index]  # closure exists (captures `value`)
         if not isinstance(value, type(cell_value)):
             return cell_value
         return value
@@ -118,20 +120,20 @@ class Progbar:
 
     def __init__(
         self,
-        target,
-        width=30,
-        verbose=1,
-        interval=0.05,
-        stateful_metrics=None,
-        unit_name="step",
-    ):
+        target: Optional[int],
+        width: int = 30,
+        verbose: int = 1,
+        interval: float = 0.05,
+        stateful_metrics: Optional[Iterable[str]] = None,
+        unit_name: str = "step",
+    ) -> None:
         self.target = target
         self.width = width
         self.verbose = verbose
         self.interval = interval
         self.unit_name = unit_name
         if stateful_metrics:
-            self.stateful_metrics = set(stateful_metrics)
+            self.stateful_metrics: set[str] = set(stateful_metrics)
         else:
             self.stateful_metrics = set()
 
@@ -145,15 +147,16 @@ class Progbar:
         self._seen_so_far = 0
         # We use a dict + list to avoid garbage collection
         # issues found in OrderedDict
-        self._values = {}
-        self._values_order = []
+        self._values: Dict[str, Any] = {}
+        self._values_order: List[str] = []
         self._start = time.time()
-        self._last_update = 0
+        self._last_update: float = 0
         self._time_at_epoch_start = self._start
-        self._time_at_epoch_end = None
-        self._time_after_first_step = None
+        self._time_at_epoch_end: Optional[float] = None
+        self._time_after_first_step: Optional[float] = None
 
-    def update(self, current, values=None, finalize=None):
+    def update(self, current: int, values: Optional[Sequence[Tuple[str, float]]] = None,
+               finalize: Optional[bool] = None) -> None:
         """Updates the progress bar.
 
         Args:
@@ -274,8 +277,9 @@ class Progbar:
 
         elif self.verbose == 2:
             if finalize:
-                numdigits = int(np.log10(self.target)) + 1
-                count = ("%" + str(numdigits) + "d/%d") % (current, self.target)
+                target = cast(int, self.target)
+                numdigits = int(np.log10(target)) + 1
+                count = ("%" + str(numdigits) + "d/%d") % (current, target)
                 info = count + info
                 for k in self._values_order:
                     info += f" - {k}:"
@@ -290,7 +294,7 @@ class Progbar:
                     time_per_epoch = (
                         self._time_at_epoch_end - self._time_at_epoch_start
                     )
-                    avg_time_per_step = time_per_epoch / self.target
+                    avg_time_per_step = time_per_epoch / target
                     self._time_at_epoch_start = now
                     self._time_at_epoch_end = None
                     info += " -" + self._format_time(time_per_epoch, "epoch")
@@ -304,10 +308,10 @@ class Progbar:
 
         self._last_update = now
 
-    def add(self, n, values=None):
+    def add(self, n: int, values: Optional[Sequence[Tuple[str, float]]] = None) -> None:
         self.update(self._seen_so_far + n, values)
 
-    def _format_time(self, time_per_unit, unit_name):
+    def _format_time(self, time_per_unit: float, unit_name: str) -> str:
         """format a given duration to display to the user.
 
         Given the duration, this function formats it in either milliseconds
@@ -327,7 +331,7 @@ class Progbar:
             formatted += f" {time_per_unit * 1000000.0:.0f}us/{unit_name}"
         return formatted
 
-    def _estimate_step_duration(self, current, now):
+    def _estimate_step_duration(self, current: int, now: float) -> float:
         """Estimate the duration of a single step.
 
         Given the step number `current` and the corresponding time `now` this
@@ -363,11 +367,11 @@ class Progbar:
         else:
             return 0
 
-    def _update_stateful_metrics(self, stateful_metrics):
+    def _update_stateful_metrics(self, stateful_metrics: Iterable[str]) -> None:
         self.stateful_metrics = self.stateful_metrics.union(stateful_metrics)
 
 
-def make_batches(size, batch_size):
+def make_batches(size: int, batch_size: int) -> List[Tuple[int, int]]:
     """Returns a list of batch indices (tuples of indices).
 
     Args:
@@ -384,7 +388,7 @@ def make_batches(size, batch_size):
     ]
 
 
-def slice_arrays(arrays, start=None, stop=None):
+def slice_arrays(arrays: Any, start: Any = None, stop: Any = None) -> Any:
     """Slice an array or list of arrays.
 
     This takes an array-like, or a list of
@@ -436,7 +440,7 @@ def slice_arrays(arrays, start=None, stop=None):
         return [None]
 
 
-def to_list(x):
+def to_list(x: Any) -> List[Any]:
     """Normalizes a list/tensor into a list.
 
     If a tensor is passed, we return
@@ -453,7 +457,7 @@ def to_list(x):
     return [x]
 
 
-def to_snake_case(name):
+def to_snake_case(name: str) -> str:
     intermediate = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
     insecure = re.sub("([a-z])([A-Z])", r"\1_\2", intermediate).lower()
     # If the class is private the name starts with "_" which is not secure
@@ -463,7 +467,8 @@ def to_snake_case(name):
     return "private" + insecure
 
 
-def check_for_unexpected_keys(name, input_dict, expected_values):
+def check_for_unexpected_keys(name: str, input_dict: Dict[str, Any],
+                              expected_values: Iterable[str]) -> None:
     unknown = set(input_dict.keys()).difference(expected_values)
     if unknown:
         raise ValueError(
@@ -473,26 +478,28 @@ def check_for_unexpected_keys(name, input_dict, expected_values):
 
 
 def validate_kwargs(
-    kwargs, allowed_kwargs, error_message="Keyword argument not understood:"
-):
+    kwargs: Iterable[str], allowed_kwargs: Container[str],
+    error_message: str = "Keyword argument not understood:"
+) -> None:
     """Checks that all keyword arguments are in the set of allowed keys."""
     for kwarg in kwargs:
         if kwarg not in allowed_kwargs:
             raise TypeError(error_message, kwarg)
 
 
-def default(method):
+def default(method: Callable[..., Any]) -> Callable[..., Any]:
     """Decorates a method to detect overrides in subclasses."""
-    method._is_default = True
+    method._is_default = True  # type: ignore[attr-defined]  # marker attribute on a callable
     return method
 
 
-def is_default(method):
+def is_default(method: Any) -> bool:
     """Check if a method is decorated with the `default` wrapper."""
-    return getattr(method, "_is_default", False)
+    return bool(getattr(method, "_is_default", False))
 
 
-def populate_dict_with_module_objects(target_dict, modules, obj_filter):
+def populate_dict_with_module_objects(target_dict: Dict[str, Any], modules: Iterable[Any],
+                                      obj_filter: Callable[[Any], bool]) -> None:
     for module in modules:
         for name in dir(module):
             obj = getattr(module, name)
@@ -503,12 +510,12 @@ def populate_dict_with_module_objects(target_dict, modules, obj_filter):
 class LazyLoader(python_types.ModuleType):
     """Lazily import a module, mainly to avoid pulling in large dependencies."""
 
-    def __init__(self, local_name, parent_module_globals, name):
+    def __init__(self, local_name: str, parent_module_globals: Dict[str, Any], name: str) -> None:
         self._local_name = local_name
         self._parent_module_globals = parent_module_globals
         super().__init__(name)
 
-    def _load(self):
+    def _load(self) -> python_types.ModuleType:
         """Load the module and insert it into the parent's globals."""
         # Import the target module and insert it into the parent's namespace
         module = importlib.import_module(self.__name__)
@@ -519,12 +526,12 @@ class LazyLoader(python_types.ModuleType):
         self.__dict__.update(module.__dict__)
         return module
 
-    def __getattr__(self, item):
+    def __getattr__(self, item: str) -> Any:
         module = self._load()
         return getattr(module, item)
 
 
-def print_msg(message, line_break=True):
+def print_msg(message: str, line_break: bool = True) -> None:
     """Print the message to absl logging or stdout."""
     if line_break:
         sys.stdout.write(message + "\n")

--- a/brainpy/types.py
+++ b/brainpy/types.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 import numbers
-from typing import TypeVar, Tuple, Union, Callable, Sequence
+from typing import Any, TypeVar, Tuple, Union, Callable, Sequence
 
 import jax
 import numpy as np
@@ -33,7 +33,7 @@ __all__ = [
 # data
 Parameter = TypeVar('Parameter', numbers.Number, jax.Array, 'Array', 'Variable')  # noqa
 ArrayType = TypeVar('ArrayType', Array, Variable, TrainVar, jax.Array, np.ndarray)  # noqa
-Array = ArrayType  # noqa
+Array = ArrayType  # type: ignore[misc,assignment]  # noqa: back-compat alias of the ArrayType TypeVar
 PyTree = TypeVar('PyTree')  # noqa
 
 # shape
@@ -43,6 +43,6 @@ Shape = TypeVar('Shape', int, Tuple[int, ...])  # noqa
 Output = TypeVar('Output')  # noqa
 Monitor = TypeVar('Monitor')  # noqa
 Connector = Union[conn.Connector, Array, Variable, jax.Array, np.ndarray]
-Initializer = Union[init.Initializer, Callable, Array, Variable, jax.Array, np.ndarray]
+Initializer = Union[init.Initializer, Callable[..., Any], Array, Variable, jax.Array, np.ndarray]
 
 Sharding = Union[Sequence[str], jax.sharding.Sharding, jax.Device]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,11 @@ tpu = ["jax[tpu]", 'brainevent[tpu]']
 [tool.setuptools]
 package-dir = { "" = "." }
 
+[tool.setuptools.package-data]
+# PEP 561: ship the inline type information marker so downstream type checkers
+# consume BrainPy's annotations.
+brainpy = ["py.typed"]
+
 [tool.setuptools.packages.find]
 where = ["."]
 exclude = [
@@ -78,3 +83,64 @@ exclude = [
 
 [tool.setuptools.dynamic]
 version = { attr = "brainpy.__version__" }
+
+# ---------------------------------------------------------------------------
+# Static type checking (mypy)
+# ---------------------------------------------------------------------------
+# BrainPy is a large (~74K LOC), JAX-based scientific library. Strict, fully
+# type-checked coverage of the whole code base is a long-term effort. To make
+# that effort incremental *and* enforceable, mypy is configured to:
+#
+#   * type-check ONLY a curated, fully-annotated subset of modules (``files``),
+#   * apply strict rules to exactly that subset (the ``overrides`` block),
+#   * resolve imports into the rest of the package silently
+#     (``follow_imports = "silent"``) so the unchecked majority neither blocks
+#     nor pollutes the curated check.
+#
+# CI runs a bare ``mypy`` (no arguments); it picks up ``files`` from here, so the
+# curated set lives in exactly one place. Grow ``files`` (and the override
+# ``module`` list) as more modules are fully typed.
+[tool.mypy]
+python_version = "3.11"
+ignore_missing_imports = true
+follow_imports = "silent"
+warn_unused_ignores = true
+warn_redundant_casts = true
+show_error_codes = true
+files = [
+    "brainpy/_errors.py",
+    "brainpy/types.py",
+    "brainpy/tools/__init__.py",
+    "brainpy/tools/codes.py",
+    "brainpy/tools/dicts.py",
+    "brainpy/tools/functions.py",
+    "brainpy/tools/install.py",
+    "brainpy/tools/math_util.py",
+    "brainpy/tools/others.py",
+    "brainpy/tools/package.py",
+    "brainpy/tools/progress.py",
+]
+
+# Strict enforcement for the curated subset only.
+[[tool.mypy.overrides]]
+module = [
+    "brainpy._errors",
+    "brainpy.types",
+    "brainpy.tools",
+    "brainpy.tools.codes",
+    "brainpy.tools.dicts",
+    "brainpy.tools.functions",
+    "brainpy.tools.install",
+    "brainpy.tools.math_util",
+    "brainpy.tools.others",
+    "brainpy.tools.package",
+    "brainpy.tools.progress",
+]
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+warn_return_any = true
+disallow_any_generics = true
+strict_equality = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,6 @@ pytest
 pytest-xdist  # for parallel test execution
 pytest-cov  # for coverage reporting (Codecov badge)
 absl-py
+
+# type-checking requirements
+mypy  # static type checking of the curated, strictly-typed subset (see [tool.mypy])


### PR DESCRIPTION
## Summary

- **Enable PEP 561**: ship a `brainpy/py.typed` marker (declared via setuptools `package-data`) so downstream type checkers consume BrainPy's inline annotations. Verified the built wheel contains `brainpy/py.typed`.
- **Comprehensive, strict-mypy-clean typing** of a curated subset of the public "fundamental supporting" surface:
  - `brainpy/_errors.py`, `brainpy/types.py`
  - `brainpy/tools/{__init__,codes,dicts,functions,install,math_util,others,package,progress}.py`
- **mypy config** in `pyproject.toml`: lenient globally with `follow_imports = "silent"` so the large, JAX-based code base neither blocks nor pollutes the check, plus a strict per-module override for the curated set. The curated files are listed in `[tool.mypy].files`, so CI runs a bare `mypy`.
- **mypy CI**: new dedicated `.github/workflows/typecheck.yml` job (Linux, Python 3.13) and `mypy` added to `requirements-dev.txt`.

## Why curated-subset?

The package is ~74K LOC with ~3% return-type coverage today; full strict-mypy coverage in one PR isn't feasible. This establishes the infrastructure (py.typed + mypy config + CI) and a strictly-typed, green-from-day-one core that can be grown incrementally by extending `[tool.mypy].files` (and the override `module` list).

## Verification

- `mypy` → `Success: no issues found in 11 source files`.
- Built wheel contains `brainpy/py.typed`.
- Existing tests pass (`brainpy/tools/functions_test.py`); smoke-tested all touched modules incl. `Progbar` in every verbose mode.
- All edits are type-only — no runtime behavior changes.

## Summary by Sourcery

Introduce static type checking infrastructure and annotations for core BrainPy utilities and errors while keeping runtime behavior unchanged.

Enhancements:
- Add type annotations and mypy-clean typing to core utility modules including tools, errors, and type aliases.
- Enable PEP 561 by shipping a py.typed marker so downstream projects can consume BrainPy's inline type hints.
- Configure mypy in pyproject.toml to strictly check a curated subset of modules while keeping global settings lenient for the rest of the codebase.

CI:
- Add a GitHub Actions workflow to run mypy against the curated strictly-typed subset on every push and pull request.