### PR TITLE
Reuse braintools.init / braintools.metric in brainpy.initialize & losses

### DIFF
--- a/brainpy/initialize/regular_inits.py
+++ b/brainpy/initialize/regular_inits.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import braintools.init as _bt_init
+
 from brainpy import math as bm, tools
 from .base import _InterLayerInitializer
 
@@ -32,7 +34,7 @@ class ZeroInit(_InterLayerInitializer):
 
     def __call__(self, shape, dtype=None):
         shape = [tools.size2num(d) for d in shape]
-        return bm.zeros(shape, dtype=dtype)
+        return bm.asarray(_bt_init.ZeroInit()(shape), dtype=dtype)
 
     def __repr__(self):
         return self.__class__.__name__
@@ -55,7 +57,7 @@ class Constant(_InterLayerInitializer):
 
     def __call__(self, shape, dtype=None):
         shape = [tools.size2num(d) for d in shape]
-        return bm.ones(shape, dtype=dtype) * self.value
+        return bm.asarray(_bt_init.Constant(self.value)(shape), dtype=dtype)
 
     def __repr__(self):
         return f'{self.__class__.__name__}(value={self.value})'
@@ -103,7 +105,11 @@ class Identity(_InterLayerInitializer):
             raise ValueError(f'Only support shape of int, or tuple/list of int '
                              f'in {self.__class__.__name__}, but we got {shape}.')
         shape = [tools.size2num(d) for d in shape]
-        return bm.eye(*shape, dtype=dtype) * self.value
+        # brainpy treats a 1D shape ``(n,)`` as a square ``(n, n)`` identity
+        # matrix; expand before delegating so braintools builds the same matrix.
+        if len(shape) == 1:
+            shape = [shape[0], shape[0]]
+        return bm.asarray(_bt_init.Identity(scale=self.value)(tuple(shape)), dtype=dtype)
 
     def __repr__(self):
         return f'{self.__class__.__name__}(value={self.value})'

--- a/brainpy/initialize/regular_inits_test.py
+++ b/brainpy/initialize/regular_inits_test.py
@@ -16,8 +16,11 @@
 import unittest
 
 import jax
+import numpy as np
 
+import braintools.init as _bt_init
 import brainpy as bp
+import brainpy.math as bm
 
 
 class TestZeroInit(unittest.TestCase):
@@ -50,3 +53,84 @@ class TestIdentityInit(unittest.TestCase):
                 else:
                     assert weights.shape == size
                 assert isinstance(weights, (bp.math.ndarray, jax.Array))
+
+
+def _np(x):
+    return np.asarray(x)
+
+
+class TestConstant(unittest.TestCase):
+    def test_scalar_value(self):
+        init = bp.init.Constant(value=3.0)
+        w = init((2, 4))
+        self.assertEqual(w.shape, (2, 4))
+        self.assertTrue((_np(w) == 3.0).all())
+        self.assertIsInstance(w, bp.math.ndarray)
+
+    def test_array_value_broadcasts(self):
+        # An array value must broadcast across the trailing dimension exactly
+        # like ``bm.ones(shape) * value`` did before the delegation.
+        init = bp.init.Constant(value=np.array([1.0, 2.0, 3.0]))
+        w = init((4, 3))
+        self.assertTrue(np.allclose(_np(w), np.broadcast_to([1.0, 2.0, 3.0], (4, 3))))
+
+    def test_dtype_propagates(self):
+        w = bp.init.Constant(value=1.0)((2, 2), dtype=jax.numpy.float16)
+        self.assertEqual(_np(w).dtype, np.float16)
+
+
+class TestZeroInitDetails(unittest.TestCase):
+    def test_values_and_dtype(self):
+        w = bp.init.ZeroInit()((3, 3), dtype=jax.numpy.float16)
+        self.assertTrue((_np(w) == 0).all())
+        self.assertEqual(_np(w).dtype, np.float16)
+        self.assertIsInstance(w, bp.math.ndarray)
+
+
+class TestOneInitEqualsOnes(unittest.TestCase):
+    def test_default_is_ones(self):
+        w = bp.init.OneInit()((2, 3))
+        self.assertTrue((_np(w) == 1.0).all())
+
+
+class TestIdentityDetails(unittest.TestCase):
+    def test_values_1d_is_square_scaled(self):
+        w = bp.init.Identity(value=2.0)((3,))
+        self.assertTrue(np.allclose(_np(w), np.eye(3) * 2.0))
+
+    def test_values_2d_rectangular(self):
+        w = bp.init.Identity(value=1.0)((2, 3))
+        self.assertTrue(np.allclose(_np(w), np.eye(2, 3)))
+
+    def test_more_than_2d_raises(self):
+        with self.assertRaises(ValueError):
+            bp.init.Identity()((2, 3, 4))
+
+    def test_invalid_shape_type_raises(self):
+        with self.assertRaises(ValueError):
+            bp.init.Identity()(1.5)
+
+
+class TestEquivalenceToBraintools(unittest.TestCase):
+    """Deterministic inits must match their braintools.init counterparts."""
+
+    def test_zero_init(self):
+        for size in [(5,), (3, 4)]:
+            self.assertTrue(np.allclose(_np(bp.init.ZeroInit()(size)),
+                                        _np(_bt_init.ZeroInit()(size))))
+
+    def test_constant(self):
+        for size in [(5,), (3, 4)]:
+            self.assertTrue(np.allclose(_np(bp.init.Constant(2.5)(size)),
+                                        _np(_bt_init.Constant(2.5)(size))))
+
+    def test_identity(self):
+        # 2D shapes delegate 1:1 to braintools.init.Identity.
+        for size in [(2, 3), (3, 3)]:
+            self.assertTrue(np.allclose(_np(bp.init.Identity(1.5)(size)),
+                                        _np(_bt_init.Identity(scale=1.5)(size))))
+        # brainpy treats a 1D shape (n,) as a request for an (n, n) identity
+        # matrix, so it expands to the square shape before delegating (whereas
+        # braintools.init.Identity((n,)) would return a 1D vector).
+        self.assertTrue(np.allclose(_np(bp.init.Identity(1.5)((4,))),
+                                    _np(_bt_init.Identity(scale=1.5)((4, 4)))))

--- a/brainpy/losses/comparison.py
+++ b/brainpy/losses/comparison.py
@@ -19,8 +19,8 @@ This module implements several loss functions.
 
 from typing import Tuple, Optional
 
+import braintools.metric as _bt_metric
 import jax.numpy as jnp
-from jax.lax import scan
 from jax.scipy.special import logsumexp
 from jax.tree_util import tree_map
 
@@ -618,12 +618,8 @@ def l1_loss(logits, targets, reduction='sum'):
       If :attr:`reduction` is ``'none'``, then :math:`(N, *)`, same shape as the input.
     """
 
-    def loss(pred, tar):
-        diff = (pred - tar).reshape((pred.shape[0], -1))
-        norm = jnp.linalg.norm(bm.as_jax(diff), ord=1, axis=1, keepdims=False)
-        return _reduce(outputs=norm, reduction=reduction)
-
-    r = tree_map(loss, logits, targets, is_leaf=_is_leaf)
+    r = tree_map(lambda pred, tar: _bt_metric.l1_loss(pred, tar, reduction=reduction),
+                 logits, targets, is_leaf=_is_leaf)
     return _multi_return(r)
 
 
@@ -649,9 +645,10 @@ def l2_loss(predicts, targets):
 
     .. [1] Bishop, Christopher M. 2006. Pattern Recognition and Machine Learning.
     """
-    r = tree_map(lambda pred, tar: 0.5 * (pred - tar) ** 2,
+    r = tree_map(lambda pred, tar: _bt_metric.l2_loss(pred, tar),
                  predicts,
-                 targets)
+                 targets,
+                 is_leaf=_is_leaf)
     return _multi_return(r)
 
 
@@ -675,7 +672,7 @@ def mean_absolute_error(x, y, axis=None, reduction: str = 'mean'):
     Returns:
         tensor of shape (d_i, ..., for i in keep_axis) containing the mean absolute error.
     """
-    r = tree_map(lambda a, b: _reduce(bm.abs(a - b), reduction=reduction, axis=axis),
+    r = tree_map(lambda a, b: _bt_metric.absolute_error(a, b, axis=axis, reduction=reduction),
                  x,
                  y,
                  is_leaf=_is_leaf)
@@ -749,7 +746,7 @@ def mean_squared_error(predicts, targets, axis=None, reduction: str = 'mean'):
     Returns:
         tensor of shape (d_i, ..., for i in keep_axis) containing the mean squared error.
     """
-    r = tree_map(lambda a, b: _reduce((a - b) ** 2, reduction, axis=axis),
+    r = tree_map(lambda a, b: _bt_metric.squared_error(a, b, axis=axis, reduction=reduction),
                  predicts,
                  targets,
                  is_leaf=_is_leaf)
@@ -800,16 +797,8 @@ def huber_loss(predicts, targets, delta: float = 1.0):
     .. [1] https://en.wikipedia.org/wiki/Huber_loss
     """
 
-    def _loss(y_predict, y_target):
-        # 0.5 * err^2                  if |err| <= d
-        # 0.5 * d^2 + d * (|err| - d)  if |err| > d
-        diff = bm.abs(y_predict - y_target)
-        r = bm.where(diff > delta,
-                     delta * (diff - .5 * delta),
-                     0.5 * diff ** 2)
-        return bm.as_jax(r)
-
-    r = tree_map(_loss, targets, predicts, is_leaf=_is_leaf)
+    r = tree_map(lambda pred, tar: _bt_metric.huber_loss(pred, tar, delta=delta),
+                 predicts, targets, is_leaf=_is_leaf)
     return _multi_return(r)
 
 
@@ -871,13 +860,8 @@ def sigmoid_binary_cross_entropy(logits, labels):
       a sigmoid cross entropy loss.
     """
 
-    def loss(pred, tar):
-        log_p = bm.log_sigmoid(pred)
-        # log(1 - sigmoid(x)) = log_sigmoid(-x), the latter more numerically stable
-        log_not_p = bm.log_sigmoid(-pred)
-        return -tar * log_p - (1. - tar) * log_not_p
-
-    r = tree_map(loss, logits, labels, is_leaf=_is_leaf)
+    r = tree_map(lambda pred, tar: _bt_metric.sigmoid_binary_cross_entropy(pred, tar),
+                 logits, labels, is_leaf=_is_leaf)
     return _multi_return(r)
 
 
@@ -899,7 +883,7 @@ def softmax_cross_entropy(logits, labels):
     Returns:
       the cross entropy loss.
     """
-    r = tree_map(lambda pred, tar: -jnp.sum(tar * bm.log_softmax(pred, axis=-1), axis=-1),
+    r = tree_map(lambda pred, tar: _bt_metric.softmax_cross_entropy(pred, tar),
                  logits,
                  labels,
                  is_leaf=_is_leaf)
@@ -924,11 +908,8 @@ def log_cosh_loss(predicts, targets):
       the log-cosh loss.
     """
 
-    def loss(pred, tar):
-        errors = bm.as_jax(pred - tar)
-        return jnp.logaddexp(errors, -errors) - jnp.log(2.0).astype(errors.dtype)
-
-    r = tree_map(loss, predicts, targets, is_leaf=_is_leaf)
+    r = tree_map(lambda pred, tar: _bt_metric.log_cosh(pred, tar),
+                 predicts, targets, is_leaf=_is_leaf)
     return _multi_return(r)
 
 
@@ -990,78 +971,9 @@ def ctc_loss_with_forward_probs(
       \log \alpha_B(t, n) and \log \alpha_L(t, n), respectively, for ``b``-th
       sequence in the batch.
     """
-    assert logits.ndim == 3
-    assert labels.ndim == 2
-    batchsize, unused_maxinputlen, num_classes = logits.shape
-    batchsize_of_labels, maxlabellen = labels.shape
-    assert (batchsize == batchsize_of_labels)
-    assert (labels.shape == label_paddings.shape)
-    assert (logits.shape[:2] == logit_paddings.shape)
-
-    logits = logits.value if isinstance(logits, bm.Array) else logits
-    logit_paddings = logit_paddings.value if isinstance(logit_paddings, bm.Array) else logit_paddings
-    labels = labels.value if isinstance(labels, bm.Array) else labels
-    label_paddings = label_paddings.value if isinstance(label_paddings, bm.Array) else label_paddings
-
-    logprobs = bm.log_softmax(logits).value
-    labellens = maxlabellen - jnp.sum(label_paddings, axis=1).astype(jnp.int32)
-
-    # repeat[b, n] == 1.0 when label[b, n] == label[b, n+1].
-    repeat = (labels[:, :-1] == labels[:, 1:]).astype(jnp.float32)
-    repeat = jnp.pad(repeat, ((0, 0), (0, 1)))
-
-    logprobs_phi = logprobs[:, :, blank_id:blank_id + 1]  # [B, T, 1]
-    logprobs_phi = jnp.transpose(logprobs_phi, (1, 0, 2))  # [T, B, 1]
-
-    one_hot = bm.one_hot(labels, num_classes=num_classes)  # [B, N, K]
-    logprobs_emit = jnp.einsum('btk,bnk->btn', logprobs, one_hot)
-    logprobs_emit = jnp.transpose(logprobs_emit, (1, 0, 2))  # [T, B, N]
-
-    logalpha_phi_init = jnp.ones(
-        (batchsize, maxlabellen + 1)) * log_epsilon  # [B, N]
-    logalpha_phi_init = logalpha_phi_init.at[:, 0].set(0.0)
-    logalpha_emit_init = jnp.ones((batchsize, maxlabellen)) * log_epsilon
-
-    def update_phi_score(phi, added_score):
-        # Update `phi[:, 1:]`` with adding `added_score` in log space.
-        return jnp.concatenate(
-            [phi[:, :1], jnp.logaddexp(phi[:, 1:], added_score)], axis=-1)
-
-    def loop_body(prev, x):
-        prev_phi, prev_emit = prev
-        # emit-to-phi epsilon transition, except if the next label is repetition
-        prev_phi_orig = prev_phi
-        prev_phi = update_phi_score(prev_phi, prev_emit + log_epsilon * repeat)
-
-        logprob_emit, logprob_phi, pad = x
-
-        # phi-to-emit transition
-        next_emit = jnp.logaddexp(prev_phi[:, :-1] + logprob_emit,
-                                  prev_emit + logprob_emit)
-        # self-loop transition
-        next_phi = prev_phi + logprob_phi
-        # emit-to-phi blank transition only when the next label is repetition
-        next_phi = update_phi_score(
-            next_phi, prev_emit + logprob_phi + log_epsilon * (1.0 - repeat))
-
-        pad = pad.reshape((batchsize, 1))
-        next_emit = pad * prev_emit + (1.0 - pad) * next_emit
-        next_phi = pad * prev_phi_orig + (1.0 - pad) * next_phi
-
-        return (next_phi, next_emit), (next_phi, next_emit)
-
-    xs = (logprobs_emit, logprobs_phi, logit_paddings.transpose((1, 0)))
-    _, (logalpha_phi, logalpha_emit) = scan(loop_body, (logalpha_phi_init, logalpha_emit_init), xs)
-
-    # last row needs to be updated with the last epsilon transition
-    logalpha_phi_last = update_phi_score(logalpha_phi[-1], logalpha_emit[-1])
-    logalpha_phi = logalpha_phi.at[-1].set(logalpha_phi_last)
-
-    # extract per_seq_loss
-    one_hot = bm.one_hot(labellens, num_classes=maxlabellen + 1).value  # [B, N+1]
-    per_seq_loss = -jnp.einsum('bn,bn->b', logalpha_phi_last, one_hot)
-
-    return per_seq_loss, logalpha_phi, logalpha_emit
+    return _bt_metric.ctc_loss_with_forward_probs(
+        logits, logit_paddings, labels, label_paddings,
+        blank_id=blank_id, log_epsilon=log_epsilon)
 
 
 def ctc_loss(logits: ArrayType,
@@ -1096,10 +1008,9 @@ def ctc_loss(logits: ArrayType,
     Returns:
       (B,)-array containing loss values for each sequence in the batch.
     """
-    per_seq_loss, _, _ = ctc_loss_with_forward_probs(
+    return _bt_metric.ctc_loss(
         logits, logit_paddings, labels, label_paddings,
         blank_id=blank_id, log_epsilon=log_epsilon)
-    return per_seq_loss
 
 
 def multi_margin_loss(predicts, targets, margin=1.0, p=1, reduction='mean'):

--- a/brainpy/losses/comparison_test.py
+++ b/brainpy/losses/comparison_test.py
@@ -1,0 +1,190 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Regression tests for :mod:`brainpy.losses.comparison`.
+
+These lock in the contract that the comparison losses which delegate to
+``braintools.metric`` stay numerically identical to the upstream
+implementation, while keeping brainpy's pytree / ``bm.Array`` envelope.
+"""
+
+import unittest
+
+import jax
+import numpy as np
+
+import braintools.metric as M
+import brainpy.math as bm
+from brainpy import losses as L
+
+
+def _arr(*shape, seed=0):
+    return bm.asarray(np.random.RandomState(seed).randn(*shape))
+
+
+def _close(a, b, atol=1e-5):
+    return np.allclose(np.asarray(a), np.asarray(b), atol=atol)
+
+
+class TestDelegatedEquivalence(unittest.TestCase):
+    """Each delegated loss must equal its braintools.metric counterpart."""
+
+    def setUp(self):
+        rng = np.random.RandomState(7)
+        self.pred = bm.asarray(rng.randn(4, 5))
+        self.tar = bm.asarray(rng.randn(4, 5))
+        self.logits = bm.asarray(rng.randn(4, 5))
+        labels = rng.rand(4, 5)
+        self.labels = bm.asarray(labels / labels.sum(-1, keepdims=True))
+
+    def test_l1_loss(self):
+        for red in ('mean', 'sum', 'none'):
+            self.assertTrue(_close(L.l1_loss(self.pred, self.tar, reduction=red),
+                                   M.l1_loss(self.pred, self.tar, reduction=red)))
+
+    def test_l2_loss(self):
+        self.assertTrue(_close(L.l2_loss(self.pred, self.tar),
+                               M.l2_loss(self.pred, self.tar)))
+
+    def test_huber_loss(self):
+        for delta in (0.5, 1.0, 2.0):
+            self.assertTrue(_close(L.huber_loss(self.pred, self.tar, delta=delta),
+                                   M.huber_loss(self.pred, self.tar, delta=delta)))
+
+    def test_softmax_cross_entropy(self):
+        self.assertTrue(_close(L.softmax_cross_entropy(self.logits, self.labels),
+                               M.softmax_cross_entropy(self.logits, self.labels)))
+
+    def test_sigmoid_binary_cross_entropy(self):
+        self.assertTrue(_close(L.sigmoid_binary_cross_entropy(self.logits, self.labels),
+                               M.sigmoid_binary_cross_entropy(self.logits, self.labels)))
+
+    def test_log_cosh_loss(self):
+        self.assertTrue(_close(L.log_cosh_loss(self.pred, self.tar),
+                               M.log_cosh(self.pred, self.tar)))
+
+    def test_mean_squared_error(self):
+        for red in ('mean', 'sum', 'none'):
+            self.assertTrue(_close(L.mean_squared_error(self.pred, self.tar, reduction=red),
+                                   M.squared_error(self.pred, self.tar, reduction=red)))
+
+    def test_mean_squared_error_axis(self):
+        self.assertTrue(_close(L.mean_squared_error(self.pred, self.tar, axis=-1, reduction='mean'),
+                               M.squared_error(self.pred, self.tar, axis=-1, reduction='mean')))
+
+    def test_mean_absolute_error(self):
+        for red in ('mean', 'sum', 'none'):
+            self.assertTrue(_close(L.mean_absolute_error(self.pred, self.tar, reduction=red),
+                                   M.absolute_error(self.pred, self.tar, reduction=red)))
+
+
+class TestReductionDefaults(unittest.TestCase):
+    """Public default ``reduction`` values must not change."""
+
+    def test_l1_loss_default_is_sum(self):
+        pred, tar = _arr(3, 4, seed=1), _arr(3, 4, seed=2)
+        self.assertTrue(_close(L.l1_loss(pred, tar),
+                               L.l1_loss(pred, tar, reduction='sum')))
+
+    def test_mse_default_is_mean(self):
+        pred, tar = _arr(3, 4, seed=1), _arr(3, 4, seed=2)
+        self.assertEqual(np.asarray(L.mean_squared_error(pred, tar)).shape, ())
+
+    def test_mae_default_is_mean(self):
+        pred, tar = _arr(3, 4, seed=1), _arr(3, 4, seed=2)
+        self.assertEqual(np.asarray(L.mean_absolute_error(pred, tar)).shape, ())
+
+
+class TestPytreeAndArrayEnvelope(unittest.TestCase):
+    """Delegation must keep pytree-input support and bm.Array acceptance."""
+
+    def test_pytree_l2_loss(self):
+        a, b = _arr(3, 4, seed=1), _arr(3, 4, seed=2)
+        flat = L.l2_loss(a, b)
+        tree = L.l2_loss({'x': a}, {'x': b})
+        self.assertTrue(_close(flat, tree))
+
+    def test_pytree_huber(self):
+        a, b = _arr(3, 4, seed=3), _arr(3, 4, seed=4)
+        flat = L.huber_loss(a, b)
+        tree = L.huber_loss({'x': a}, {'x': b})
+        self.assertTrue(_close(flat, tree))
+
+    def test_pytree_multi_leaf_sums(self):
+        a, b = _arr(3, 4, seed=5), _arr(3, 4, seed=6)
+        # two identical leaves -> _multi_return sums them -> 2x single leaf
+        single = L.mean_squared_error(a, b, reduction='sum')
+        multi = L.mean_squared_error({'x': a, 'y': a}, {'x': b, 'y': b}, reduction='sum')
+        self.assertTrue(_close(2.0 * np.asarray(single), multi))
+
+    def test_accepts_bm_array(self):
+        a, b = _arr(2, 3, seed=8), _arr(2, 3, seed=9)
+        self.assertIsNotNone(L.l1_loss(a, b))
+
+
+class TestCTC(unittest.TestCase):
+    """ctc_loss / ctc_loss_with_forward_probs delegate to braintools.metric."""
+
+    def setUp(self):
+        rng = np.random.RandomState(0)
+        self.B, self.T, self.K, self.N = 2, 6, 4, 3
+        self.logits = bm.asarray(rng.randn(self.B, self.T, self.K))
+        self.logit_pad = bm.asarray(np.zeros((self.B, self.T)))
+        self.labels = bm.asarray(rng.randint(1, self.K, size=(self.B, self.N)))
+        self.label_pad = bm.asarray(np.zeros((self.B, self.N)))
+
+    def test_ctc_loss_matches(self):
+        a = L.ctc_loss(self.logits, self.logit_pad, self.labels, self.label_pad)
+        b = M.ctc_loss(self.logits, self.logit_pad, self.labels, self.label_pad)
+        self.assertEqual(np.asarray(a).shape, (self.B,))
+        self.assertTrue(_close(a, b))
+
+    def test_ctc_forward_probs_matches(self):
+        la, pa, na = L.ctc_loss_with_forward_probs(
+            self.logits, self.logit_pad, self.labels, self.label_pad)
+        lb, pb, nb = M.ctc_loss_with_forward_probs(
+            self.logits, self.logit_pad, self.labels, self.label_pad)
+        self.assertEqual(np.asarray(la).shape, (self.B,))
+        self.assertTrue(_close(la, lb))
+        self.assertTrue(_close(pa, pb))
+        self.assertTrue(_close(na, nb))
+
+
+class TestUntouchedLosses(unittest.TestCase):
+    """Losses with no safe braintools equivalent keep working unchanged."""
+
+    def test_cross_entropy_loss_runs(self):
+        rng = np.random.RandomState(2)
+        logits = bm.asarray(rng.randn(4, 5))
+        targets = bm.asarray(rng.randint(0, 5, size=(4,)))
+        self.assertEqual(np.asarray(L.cross_entropy_loss(logits, targets)).shape, ())
+
+    def test_cross_entropy_sparse_runs(self):
+        rng = np.random.RandomState(2)
+        logits = bm.asarray(rng.randn(4, 5))
+        targets = bm.asarray(rng.randint(0, 5, size=(4, 1)))
+        self.assertEqual(np.asarray(L.cross_entropy_sparse(logits, targets)).shape, (4,))
+
+    def test_multi_margin_loss_runs(self):
+        rng = np.random.RandomState(2)
+        # multi_margin_loss indexes ``predicts`` by ``targets``; use plain
+        # jax/numpy inputs (the supported indexing path) since this function
+        # is intentionally left untouched.
+        logits = bm.as_jax(bm.asarray(rng.randn(4, 5)))
+        targets = rng.randint(0, 5, size=(4,))
+        self.assertIsNotNone(L.multi_margin_loss(logits, targets))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/brainpy/losses/regularization.py
+++ b/brainpy/losses/regularization.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import braintools.metric as _bt_metric
 import jax.numpy as jnp
 from jax.tree_util import tree_flatten, tree_map
 
@@ -47,12 +48,14 @@ def mean_absolute(outputs, axis=None):
     Returns:
         tensor of shape (d_i, ..., for i in keep_axis) containing the mean absolute error.
     """
-    r = tree_map(lambda a: bm.mean(bm.abs(a), axis=axis), outputs, is_leaf=_is_leaf)
+    r = tree_map(lambda a: _bt_metric.absolute_error(a, None, axis=axis, reduction='mean'),
+                 outputs, is_leaf=_is_leaf)
     return _multi_return(r)
 
 
 def mean_square(predicts, axis=None):
-    r = tree_map(lambda a: bm.mean(a ** 2, axis=axis), predicts, is_leaf=_is_leaf)
+    r = tree_map(lambda a: _bt_metric.squared_error(a, None, axis=axis, reduction='mean'),
+                 predicts, is_leaf=_is_leaf)
     return _multi_return(r)
 
 
@@ -68,7 +71,7 @@ def log_cosh(errors):
     Returns:
       the log-cosh loss.
     """
-    r = tree_map(lambda a: bm.logaddexp(a, -a) - bm.log(2.0).astype(a.dtype),
+    r = tree_map(lambda a: _bt_metric.log_cosh(a),
                  errors, is_leaf=_is_leaf)
     return _multi_return(r)
 
@@ -87,6 +90,6 @@ def smooth_labels(labels, alpha: float) -> jnp.ndarray:
     Returns:
       a smoothed version of the one hot input labels.
     """
-    r = tree_map(lambda tar: (1.0 - alpha) * tar + alpha / tar.shape[-1],
+    r = tree_map(lambda tar: _bt_metric.smooth_labels(tar, alpha),
                  labels, is_leaf=lambda x: isinstance(x, bm.Array))
     return _multi_return(r)

--- a/brainpy/losses/regularization_test.py
+++ b/brainpy/losses/regularization_test.py
@@ -1,0 +1,89 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Regression tests for :mod:`brainpy.losses.regularization`."""
+
+import unittest
+
+import numpy as np
+
+import braintools.metric as M
+import brainpy.math as bm
+from brainpy import losses as L
+
+
+def _close(a, b, atol=1e-5):
+    return np.allclose(np.asarray(a), np.asarray(b), atol=atol)
+
+
+class TestDelegatedEquivalence(unittest.TestCase):
+    def setUp(self):
+        rng = np.random.RandomState(11)
+        self.x = bm.asarray(rng.randn(4, 5))
+        self.y = bm.asarray(rng.randn(4, 5))
+        oh = np.eye(5)[rng.randint(0, 5, size=(4,))]
+        self.onehot = bm.asarray(oh)
+
+    def test_log_cosh(self):
+        self.assertTrue(_close(L.log_cosh(self.x), M.log_cosh(self.x)))
+
+    def test_smooth_labels(self):
+        for alpha in (0.0, 0.1, 0.5):
+            self.assertTrue(_close(L.smooth_labels(self.onehot, alpha),
+                                   M.smooth_labels(self.onehot, alpha)))
+
+    def test_mean_square(self):
+        self.assertTrue(_close(L.mean_square(self.x),
+                               M.squared_error(self.x, None, reduction='mean')))
+
+    def test_mean_square_axis(self):
+        self.assertTrue(_close(L.mean_square(self.x, axis=-1),
+                               M.squared_error(self.x, None, axis=-1, reduction='mean')))
+
+    def test_mean_absolute(self):
+        self.assertTrue(_close(L.mean_absolute(self.x),
+                               M.absolute_error(self.x, None, reduction='mean')))
+
+    def test_mean_absolute_axis(self):
+        self.assertTrue(_close(L.mean_absolute(self.x, axis=0),
+                               M.absolute_error(self.x, None, axis=0, reduction='mean')))
+
+
+class TestPytreeEnvelope(unittest.TestCase):
+    def test_smooth_labels_pytree(self):
+        rng = np.random.RandomState(3)
+        oh = bm.asarray(np.eye(4)[rng.randint(0, 4, size=(5,))])
+        flat = L.smooth_labels(oh, 0.2)
+        tree = L.smooth_labels({'a': oh}, 0.2)
+        self.assertTrue(_close(flat, tree))
+
+    def test_mean_square_pytree_sums_leaves(self):
+        rng = np.random.RandomState(4)
+        a = bm.asarray(rng.randn(3, 3))
+        single = L.mean_square(a)
+        multi = L.mean_square({'x': a, 'y': a})
+        self.assertTrue(_close(2.0 * np.asarray(single), multi))
+
+
+class TestL2NormUnchanged(unittest.TestCase):
+    """l2_norm has a different definition upstream and stays as brainpy's."""
+
+    def test_l2_norm_is_sqrt_sum_squares(self):
+        x = bm.asarray(np.array([3.0, 4.0]))
+        # brainpy l2_norm == Euclidean norm == 5.0 for [3, 4]
+        self.assertTrue(_close(L.l2_norm(x), 5.0))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Removes duplicated implementations in `brainpy.initialize` and `brainpy.losses` by delegating to the upstream `braintools` package (already a hard dependency, and already reused by `brainpy.measure`, `brainpy.math.surrogate`, `brainpy.visualization`, `brainpy.inputs`). Public API, pytree support, `dtype` handling and `bm.Array` return types are all preserved.

### `brainpy.initialize` (conservative reuse of `braintools.init`)
- `ZeroInit`, `Constant` (and `OneInit`), `Identity` now delegate their construction to `braintools.init.{ZeroInit,Constant,Identity}`, keeping brainpy signatures, the `<=2D` `Identity` validation and the 1D→square expansion.
- Seeded random initializers (`Normal`, `Uniform`, `Kaiming*`, `Xavier*`, `Lecun*`, `Orthogonal`, …) are **left untouched**: `braintools.init`'s random initializers are unseeded and use incompatible constructor signatures (`Normal(mean, std)`, no `seed`, `__call__(size)` without `dtype`), so replacing them would break reproducibility and the public API.

### `brainpy.losses` (reuse of `braintools.metric`)
The following now compute via `braintools.metric` inside brainpy's existing `tree_map`/`_multi_return` envelope (so **pytree inputs still work**):
`l1_loss`, `l2_loss`, `huber_loss`, `softmax_cross_entropy`, `sigmoid_binary_cross_entropy`, `log_cosh_loss`, `mean_squared_error`, `mean_absolute_error`, and regularization `log_cosh`, `smooth_labels`, `mean_square`, `mean_absolute`.

`ctc_loss` / `ctc_loss_with_forward_probs` delegate directly — this also **fixes a pre-existing crash** (`bm.log_softmax(<jax array>).value`, where jax arrays have no `.value`).

Left unchanged where braintools has no behavior-equivalent counterpart: `l2_norm` (different formula), `cross_entropy_loss`, `cross_entropy_sparse`/`cross_entropy_sigmoid`, `nll_loss`, `binary/multiclass_logistic_loss`, `multi_margin_loss`, `mean_squared_log_error`.

## Testing
- New co-located regression tests (`comparison_test.py`, `regularization_test.py`, extended `regular_inits_test.py`) assert numerical equivalence to `braintools` across reductions/axis and for pytree + `bm.Array` inputs.
- `pytest brainpy/initialize brainpy/losses` → **67 passed**.
- Non-JitFP `brainpy/dnn/linear_test.py` (heavy initializer consumer) → **16 passed**. (Pre-existing JitFP failures are unrelated and reproduce on `master`.)

## Summary by Sourcery

Delegate selected deterministic initializers and loss/regularization functions to the existing braintools implementations while preserving BrainPy’s public APIs and pytree/Array handling, and add regression tests to lock in equivalence and behavior.

Bug Fixes:
- Fix CTC loss functions by delegating to braintools.metric, resolving crashes when called with JAX arrays that lack a `.value` attribute.

Enhancements:
- Reuse braintools.init for ZeroInit, Constant/OneInit, and Identity initializers to avoid duplicated logic while keeping shapes, dtypes, and BrainPy-specific identity behavior intact.
- Reuse braintools.metric for core comparison losses and regularization helpers (L1/L2, Huber, softmax/sigmoid cross-entropy, log-cosh, mean absolute/squared errors, smoothing) while retaining BrainPy’s pytree and bm.Array envelopes.

Tests:
- Add regression tests for deterministic initializers to ensure value/dtype behavior and equivalence with braintools.init.
- Add comparison and regularization regression tests to ensure delegated losses and regularizers remain numerically identical to braintools.metric and preserve reduction defaults and pytree semantics.
- Add tests to validate CTC loss delegation and to confirm non-delegated legacy losses continue to run as before.