### PR TITLE
fix(examples): repair 6 broken example scripts (API drift, data path, channels)

### DIFF
--- a/examples/dynamics_analysis/highdim_RNN_Analysis.py
+++ b/examples/dynamics_analysis/highdim_RNN_Analysis.py
@@ -36,7 +36,7 @@ class RNNNet(bp.DynamicalSystem):
             self.alpha = 1
         else:
             self.alpha = dt / self.tau
-        self.rng = bm.random.RandomState(seed=seed)
+        self.rng = bm.random.RandomState(seed)
 
         # input weight
         self.w_ir = bm.TrainVar(bp.init.parameter(w_ir, (num_input, num_hidden)))

--- a/examples/dynamics_simulation/whole_brain_simulation_with_fhn.py
+++ b/examples/dynamics_simulation/whole_brain_simulation_with_fhn.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 
+import os
+
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -25,11 +27,11 @@ class Network(bp.DynSysGroup):
     def __init__(self, signal_speed=20.):
         super(Network, self).__init__()
 
-        # Please download the processed data "hcp.npz" of the
-        # ConnectomeDB of the Human Connectome Project (HCP)
-        # from the following link:
-        # - https://share.weiyun.com/wkPpARKy
-        hcp = np.load('../../tests/simulation/data/hcp.npz')
+        # HCP connectome data ("hcp.npz", processed from the ConnectomeDB of
+        # the Human Connectome Project) is bundled with BrainPy at
+        # ``brainpy/dyn/rates/data/hcp.npz``.
+        hcp_path = os.path.join(os.path.dirname(bp.__file__), 'dyn', 'rates', 'data', 'hcp.npz')
+        hcp = np.load(hcp_path)
         conn_mat = bm.asarray(hcp['Cmat'])
         bm.fill_diagonal(conn_mat, 0)
         delay_mat = bm.round(hcp['Dmat'] / signal_speed / bm.dt).astype(bm.int_)

--- a/examples/dynamics_simulation/whole_brain_simulation_with_sl_oscillator.py
+++ b/examples/dynamics_simulation/whole_brain_simulation_with_sl_oscillator.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import os
+
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -26,11 +28,11 @@ class Network(bp.DynSysGroup):
     def __init__(self, noise=0.14):
         super(Network, self).__init__()
 
-        # Please download the processed data "hcp.npz" of the
-        # ConnectomeDB of the Human Connectome Project (HCP)
-        # from the following link:
-        # - https://share.weiyun.com/wkPpARKy
-        hcp = np.load('../../tests/simulation/data/hcp.npz')
+        # HCP connectome data ("hcp.npz", processed from the ConnectomeDB of
+        # the Human Connectome Project) is bundled with BrainPy at
+        # ``brainpy/dyn/rates/data/hcp.npz``.
+        hcp_path = os.path.join(os.path.dirname(bp.__file__), 'dyn', 'rates', 'data', 'hcp.npz')
+        hcp = np.load(hcp_path)
         conn_mat = bm.asarray(hcp['Cmat'])
         bm.fill_diagonal(conn_mat, 0)
         gc = 0.6  # global coupling strength

--- a/examples/dynamics_training/Song_2016_EI_RNN.py
+++ b/examples/dynamics_training/Song_2016_EI_RNN.py
@@ -38,7 +38,7 @@ class EI_RNN(bp.DynamicalSystem):
         self.i_size = num_hidden - self.e_size
         self.alpha = dt / self.tau
         self.sigma_rec = (2 * self.alpha) ** 0.5 * sigma_rec  # Recurrent noise
-        self.rng = bm.random.RandomState(seed=seed)
+        self.rng = bm.random.RandomState(seed)
 
         # hidden mask
         mask = np.tile([1] * self.e_size + [-1] * self.i_size, (num_hidden, 1))

--- a/examples/dynamics_training/integrate_flax_into_brainpy.py
+++ b/examples/dynamics_training/integrate_flax_into_brainpy.py
@@ -30,7 +30,7 @@ class Network(bp.DynamicalSystem):
     def __init__(self):
         super(Network, self).__init__()
         self.cnn = bp.layers.FromFlax(CNN(), bm.ones([1, 4, 28, 1]))
-        self.rnn = bp.layers.GRUCell(256, 100)
+        self.rnn = bp.dyn.GRUCell(256, 100)
         self.linear = bp.layers.Dense(100, 10)
 
     def update(self, x):

--- a/examples/training_ann_models/mnist_ResNet.py
+++ b/examples/training_ann_models/mnist_ResNet.py
@@ -89,11 +89,11 @@ class Bottleneck(bp.DynamicalSystem):
 
 
 class ResNet(bp.DynamicalSystem):
-    def __init__(self, block, num_blocks, num_classes=10, zero_init_residual=False):
+    def __init__(self, block, num_blocks, num_classes=10, in_channels=3, zero_init_residual=False):
         super(ResNet, self).__init__()
         self.in_planes = 64
 
-        self.conv1 = bp.layers.Conv2D(3, 64, kernel_size=(3, 3), strides=(1, 1), padding=(1, 1),
+        self.conv1 = bp.layers.Conv2D(in_channels, 64, kernel_size=(3, 3), strides=(1, 1), padding=(1, 1),
                                       w_initializer=weight_init)
         self.bn1 = bp.layers.BatchNorm2D(64)
         self.layer1 = self._make_layer(block, 64, num_blocks[0], stride=1)
@@ -208,7 +208,7 @@ def main():
     y_test = bm.asarray(test_set.targets, dtype=bm.int_)
 
     with bm.training_environment():
-        net = ResNet18(num_classes=10)
+        net = ResNet18(num_classes=10, in_channels=1)
 
     # loss function
     def loss_fun(X, Y, fit=True):


### PR DESCRIPTION
## Summary

Ran a crash-safe, strictly-sequential triage of **all 24 `examples/` scripts**
(isolated subprocess each, `ulimit -v` capped, thread-capped, headless `Agg`,
OS timeout, `PYTHONPATH`=repo so imports resolve to this source). Result:
**14 already pass**, **6 fixed here**, **4 unchanged** (need optional deps or
exceed the time budget).

## Fixes (all verified green)

| Example | Bug | Fix |
|---|---|---|
| `integrate_flax_into_brainpy` | `bp.layers.GRUCell` removed | → `bp.dyn.GRUCell` |
| `whole_brain_simulation_with_fhn` | dead `../../tests/simulation/data/hcp.npz` path | load bundled `brainpy/dyn/rates/data/hcp.npz` via package dir |
| `whole_brain_simulation_with_sl_oscillator` | same dead `hcp.npz` path | same |
| `Song_2016_EI_RNN` | `RandomState(seed=...)` kwarg renamed | → positional `RandomState(seed)` |
| `highdim_RNN_Analysis` | same `RandomState(seed=...)` | same |
| `mnist_ResNet` | first conv hardcoded `in_channels=3` vs 1-channel MNIST → `ValueError` | parameterize `in_channels` (default 3), pass `1` for MNIST |

Verification: heavy scripts smoke-tested (network construction + one forward
pass / 20 ms sim); `Song_2016_EI_RNN` (95% acc) and `highdim_RNN_Analysis`
(fixed-point search) run to completion.

## Unchanged (documented, not bugs)

- `reservoir-mnist` — functional but ~11 min of training (exceeds the 10 min sandbox timeout).
- `integrate_brainpy_into_flax-lif`, `integrate_brainpy_into_flax-convlstm` — require `tensorflow_datasets`.
- `spikebased_bp_for_cifar10` — requires `torch`.

## Summary by Sourcery

Update several example scripts to align with current BrainPy APIs, bundled data locations, and dataset channel configurations.

Bug Fixes:
- Load HCP connectome data in whole brain simulation examples from the bundled BrainPy package path instead of a removed test-data path.
- Adjust the ResNet example to parameterize input channels and use a single-channel configuration for MNIST to avoid shape errors.
- Update RNN-related examples to construct RandomState with a positional seed argument compatible with the current BrainPy random API.
- Switch the Flax integration example to use the current GRUCell location in BrainPy's dynamical systems module.