### PR TITLE
fix(dyn): PoissonGroup never spikes due to boolean rand_like dtype

### DIFF
--- a/brainpy/dyn/others/input.py
+++ b/brainpy/dyn/others/input.py
@@ -230,10 +230,11 @@ class PoissonGroup(NeuDyn):
         self.reset_state(self.mode)
 
     def update(self):
-        spikes = bm.random.rand_like(self.spike.value) <= (self.freqs * share['dt'] / 1000.)
+        # ``dtype=float`` is required: ``self.spike`` is boolean, and ``rand_like``
+        # defaults to the input dtype. Without it the draw is boolean (~all True),
+        # making the ``<= prob`` comparison always False so the group never fires.
+        spikes = bm.random.rand_like(self.spike.value, dtype=float) <= (self.freqs * share['dt'] / 1000.)
         spikes = bm.asarray(spikes, dtype=self.spk_type)
-        # import jax
-        # jax.debug.print('PoissonGroup: freqs = {f}, spikes = {s}', f=self.freqs, s=spikes)
         self.spike.value = spikes
         return spikes
 

--- a/brainpy/dyn/others/input_test.py
+++ b/brainpy/dyn/others/input_test.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import numpy as np
 from absl.testing import parameterized
 
 import brainpy as bp
+import brainpy.math as bm
 from brainpy.dyn.others import input
 
 
@@ -35,3 +37,36 @@ class Test_input(parameterized.TestCase):
                              progress_bar=False)
         runner.run(30.)
         self.assertTupleEqual(runner.mon['spike'].shape, (300, 2))
+
+    def test_PoissonGroup_fires_at_expected_rate(self):
+        # Regression: PoissonGroup must actually emit spikes at ~freqs Hz.
+        # A dtype bug (boolean rand_like) previously made it fire at 0 Hz while
+        # still returning the correct output shape, so a shape-only check missed it.
+        bm.random.seed(1234)
+        freqs = 200.  # Hz
+        num = 200
+        duration = 1000.  # ms
+        model = input.PoissonGroup(size=num, freqs=freqs)
+        runner = bp.DSRunner(model, monitors=['spike'], progress_bar=False)
+        runner.run(duration)
+        spikes = np.asarray(runner.mon['spike'])
+        empirical_rate = spikes.sum() / num / (duration / 1000.)
+        # Poisson counting noise here is < 1%; 15% tolerance is safe yet still
+        # rejects the 0 Hz regression by a wide margin.
+        self.assertAlmostEqual(empirical_rate, freqs, delta=0.15 * freqs)
+
+    def test_PoissonGroup_fires_in_batching_mode(self):
+        # The float draw must preserve the batched shape of ``spike`` and still
+        # produce the expected rate across the batch axis.
+        bm.random.seed(1234)
+        freqs = 200.  # Hz
+        num, batch = 30, 4
+        duration = 1000.  # ms
+        model = input.PoissonGroup(size=num, freqs=freqs, mode=bm.BatchingMode(batch))
+        runner = bp.DSRunner(model, monitors=['spike'], progress_bar=False)
+        runner.run(duration)
+        spikes = np.asarray(runner.mon['spike'])  # (batch, time, num)
+        self.assertEqual(spikes.shape[0], batch)
+        self.assertEqual(spikes.shape[-1], num)
+        empirical_rate = spikes.sum() / (batch * num) / (duration / 1000.)
+        self.assertAlmostEqual(empirical_rate, freqs, delta=0.15 * freqs)


### PR DESCRIPTION
## Problem

`PoissonGroup` never emitted spikes. In `PoissonGroup.update`, the random draw used
`rand_like(self.spike.value)`. Since `spike` is boolean-typed and `rand_like` inherits the
input dtype, the draw was boolean (≈ all `True`), so the comparison `True <= prob` was always
`False` and the group never fired.

Because both `examples/dynamics_simulation/decision_making_network.py` and
`examples/dynamics_simulation/stdp.py` are driven entirely by `PoissonGroup`, the decision
network was silent (0 Hz in every population) and STDP weights stayed frozen.

## Fix

Force a real uniform draw with `dtype=float`:

```python
spikes = bm.random.rand_like(self.spike.value, dtype=float) <= (self.freqs * share['dt'] / 1000.)
```

## Tests

The existing `test_PoissonGroup` only asserted output *shape*, which is why the regression
slipped through. Added:

- `test_PoissonGroup_fires_at_expected_rate` — asserts empirical rate ≈ `freqs` (0 Hz on old code).
- `test_PoissonGroup_fires_in_batching_mode` — covers batched shape preservation + rate.

## Verification

- `input_test.py` + `STDP_test.py`: 139 passed.
- Decision network: Group A wins at 41.8 Hz (persistent delay activity), Group B suppressed to 0.4 Hz.
- STDP: `max|ΔW|` over 10 s = 0.0032 (weights now evolve).

## Summary by Sourcery

Ensure PoissonGroup emits spikes by fixing its random draw dtype and strengthen tests to verify firing rates, including in batching mode.

Bug Fixes:
- Fix PoissonGroup spike generation by forcing uniform random draws to use a floating-point dtype instead of inheriting the boolean spike dtype.

Tests:
- Add tests asserting PoissonGroup fires at the expected rate over time.
- Add a batching-mode PoissonGroup test verifying both batched spike shape and firing rate.