### PR TITLE
fix: SupportSTDP.stdp_update keyword typo and DSRunner deprecation warning

### DIFF
--- a/brainpy/dnn/linear.py
+++ b/brainpy/dnn/linear.py
@@ -226,7 +226,7 @@ class Dense(Layer, SupportSTDP, SupportOnline, SupportOffline):
             self.W.value = Wff
             self.b.value = bias[0]
 
-    def stdp_update(  # type: ignore[override]  # base SupportSTDP.stdp_update is a permissive *args/**kwargs placeholder (with an `onn_post` typo); concrete overrides declare explicit params
+    def stdp_update(  # type: ignore[override]  # base SupportSTDP.stdp_update is a permissive *args/**kwargs placeholder; concrete overrides declare explicit params
         self,
         on_pre: Optional[Dict] = None,
         on_post: Optional[Dict] = None,
@@ -334,7 +334,7 @@ class AllToAll(Layer, SupportSTDP):
                 post_val = pre_val @ self.weight
         return post_val
 
-    def stdp_update(  # type: ignore[override]  # base SupportSTDP.stdp_update is a permissive *args/**kwargs placeholder (with an `onn_post` typo); concrete overrides declare explicit params
+    def stdp_update(  # type: ignore[override]  # base SupportSTDP.stdp_update is a permissive *args/**kwargs placeholder; concrete overrides declare explicit params
         self,
         on_pre: Optional[Dict] = None,
         on_post: Optional[Dict] = None,
@@ -397,7 +397,7 @@ class OneToOne(Layer, SupportSTDP):
     def update(self, pre_val):
         return pre_val * self.weight
 
-    def stdp_update(  # type: ignore[override]  # base SupportSTDP.stdp_update is a permissive *args/**kwargs placeholder (with an `onn_post` typo); concrete overrides declare explicit params
+    def stdp_update(  # type: ignore[override]  # base SupportSTDP.stdp_update is a permissive *args/**kwargs placeholder; concrete overrides declare explicit params
         self,
         on_pre: Optional[Dict] = None,
         on_post: Optional[Dict] = None,
@@ -484,7 +484,7 @@ class MaskedLinear(Layer, SupportSTDP):
     def update(self, x):
         return x @ self.mask_fun(self.weight * self.mask)
 
-    def stdp_update(  # type: ignore[override]  # base SupportSTDP.stdp_update is a permissive *args/**kwargs placeholder (with an `onn_post` typo); concrete overrides declare explicit params
+    def stdp_update(  # type: ignore[override]  # base SupportSTDP.stdp_update is a permissive *args/**kwargs placeholder; concrete overrides declare explicit params
         self,
         on_pre: Optional[Dict] = None,
         on_post: Optional[Dict] = None,
@@ -535,7 +535,7 @@ class _CSRLayer(Layer, SupportSTDP):
             w = bm.TrainVar(w)
         self.weight = w
 
-    def stdp_update(  # type: ignore[override]  # base SupportSTDP.stdp_update is a permissive *args/**kwargs placeholder (with an `onn_post` typo); concrete overrides declare explicit params
+    def stdp_update(  # type: ignore[override]  # base SupportSTDP.stdp_update is a permissive *args/**kwargs placeholder; concrete overrides declare explicit params
         self,
         on_pre: Optional[Dict] = None,
         on_post: Optional[Dict] = None,

--- a/brainpy/mixin.py
+++ b/brainpy/mixin.py
@@ -544,5 +544,5 @@ class SupportSTDP(MixIn):
     """Support synaptic plasticity by modifying the weights.
     """
 
-    def stdp_update(self, *args, on_pre=None, onn_post=None, **kwargs):
+    def stdp_update(self, *args, on_pre=None, on_post=None, **kwargs):
         raise NotImplementedError

--- a/brainpy/runners.py
+++ b/brainpy/runners.py
@@ -452,9 +452,9 @@ class DSRunner(Runner):
         """
 
         if inputs_are_batching is not None:
-            raise warnings.warn(  # type: ignore[misc]  # latent bug: warnings.warn returns None; preserved to avoid behavior change
+            warnings.warn(
                 f'''
-        `inputs_are_batching` is no longer supported. 
+        `inputs_are_batching` is no longer supported.
         The target mode of {self.target.mode} has already indicated the input should be batching.
         ''',
                 UserWarning


### PR DESCRIPTION
Fixes the two latent runtime bugs flagged during the package-wide mypy pass (#863).

## 1. `brainpy/mixin.py` — `onn_post` keyword typo
The base `SupportSTDP.stdp_update` placeholder declared the keyword `onn_post`, while every concrete override (`brainpy/dnn/linear.py`) and every caller (`brainpy/dyn/projections/plasticity.py`, tests) uses `on_post`. The placeholder body only `raise NotImplementedError`, so this was a contract/signature defect rather than a wrong-result bug, but it was the source of the STDP `[override]` friction. Signature aligned to `on_post`.

The five overrides keep their targeted `# type: ignore[override]` (the base remains a permissive `*args/**kwargs` placeholder vs. their explicit params, so the LSP mismatch stands), but their comments no longer reference the now-fixed typo.

## 2. `brainpy/runners.py:455` — `raise warnings.warn(...)`
`DSRunner.predict` did `raise warnings.warn(...)` for the deprecated `inputs_are_batching` argument. `warnings.warn` returns `None`, so `raise None` produced `TypeError: exceptions must derive from BaseException` instead of a warning. Now emits the `UserWarning` and continues, as intended.

## Validation
- `python -m mypy brainpy/` → `Success: no issues found in 432 source files`.
- New runtime check: `predict(..., inputs_are_batching=True)` now warns and continues (previously raised `TypeError`).
- Base `SupportSTDP.stdp_update` now accepts `on_post=` and still raises `NotImplementedError`.
- STDP suites (`boost_linear_test.py`, `mixin_coverage_test.py`, `test_dense_stdp_update_promotes_weight`): 91 passed.

## Summary by Sourcery

Align STDP mixin and linear layer signatures and fix DSRunner deprecation handling so it emits a warning instead of raising an error.

Bug Fixes:
- Correct the SupportSTDP.stdp_update keyword name from onn_post to on_post to match concrete implementations and callers.
- Fix DSRunner.predict to use warnings.warn for the deprecated inputs_are_batching argument instead of incorrectly raising its return value.