### PR TITLE
refactor: move __version__ and __version_info__ into _version.py

### DIFF
--- a/brainpy/__init__.py
+++ b/brainpy/__init__.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 # ==============================================================================
 
-__version__ = "2.8.0"
-__version_info__ = tuple(map(int, __version__.split(".")))
+from brainpy._version import __version__ as __version__
+from brainpy._version import __version_info__ as __version_info__
 
 from brainpy import _errors as errors
 # fundamental supporting modules

--- a/brainpy/_version.py
+++ b/brainpy/_version.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+__version__ = "2.8.0"
+__version_info__ = tuple(map(int, __version__.split(".")))


### PR DESCRIPTION
Extract the version definitions from `brainpy/__init__.py` into a dedicated `brainpy/_version.py` module and re-export them from the package root.

- `brainpy._version` is now the single source of truth for the version string.
- `brainpy/__init__.py` re-exports `__version__` and `__version_info__`, so `pyproject`'s `version = { attr = "brainpy.__version__" }` still resolves.
- `_version.py` is already listed in the coverage omit lists in `pyproject.toml`.

Verified `import brainpy` yields `2.8.0` / `(2, 8, 0)`.

## Summary by Sourcery

Enhancements:
- Introduce brainpy._version as the single source of truth for __version__ and __version_info__ and re-export these attributes from brainpy.__init__.py.