### PR TITLE
Update branch references from master to main

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -31,7 +31,7 @@ jobs:
 
 
             If you're interested in contributing code, check out our
-            [Contributing Guide](https://github.com/brainpy/BrainPy/blob/master/CONTRIBUTING.md)
+            [Contributing Guide](https://github.com/brainpy/BrainPy/blob/main/CONTRIBUTING.md)
             for more information on how to get started.
 
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   	<a href="https://brainpy.readthedocs.io/en/latest/?badge=latest"><img alt="Documentation" src="https://readthedocs.org/projects/brainpy/badge/?version=latest"></a>
   	<a href="https://badge.fury.io/py/brainpy"><img alt="PyPI version" src="https://badge.fury.io/py/brainpy.svg"></a>
     <a href="https://github.com/brainpy/BrainPy/actions/workflows/CI.yml"><img alt="Continuous Integration" src="https://github.com/brainpy/BrainPy/actions/workflows/CI.yml/badge.svg"></a>
-    <a href="https://codecov.io/gh/brainpy/BrainPy"><img alt="Test Coverage" src="https://codecov.io/gh/brainpy/BrainPy/branch/master/graph/badge.svg"></a>
+    <a href="https://codecov.io/gh/brainpy/BrainPy"><img alt="Test Coverage" src="https://codecov.io/gh/brainpy/BrainPy/branch/main/graph/badge.svg"></a>
 </p>
 
 

--- a/docs/brainpy-changelog.md
+++ b/docs/brainpy-changelog.md
@@ -318,7 +318,7 @@ a2, b2 = prim(np.random.random(1000), np.random.random(1000),
 
 ##### 6. Generalized STDP models which are compatible with diverse synapse models.
 
-See https://github.com/brainpy/BrainPy/blob/master/brainpy/_src/dyn/projections/tests/test_STDP.py
+See https://github.com/brainpy/BrainPy/blob/main/brainpy/_src/dyn/projections/tests/test_STDP.py
 
 
 #### What's Changed


### PR DESCRIPTION
The repository default branch has been renamed from `master` to `main`. This PR updates the remaining hard-coded branch references so links resolve against the new default branch:

- **README.md** — codecov coverage badge (`branch/master` → `branch/main`)
- **.github/workflows/greetings.yml** — Contributing Guide link (`blob/master` → `blob/main`)
- **docs/brainpy-changelog.md** — permalink to `test_STDP.py` (`blob/master` → `blob/main`)

Domain-code occurrences of `master` (e.g. `master_type`, `register_master` in ion channels / synapses) and the external `sphinx-doc.org/en/master` URL are intentionally left unchanged. CI workflows already trigger on `branches: ['**']`, so no workflow trigger changes are needed.

## Summary by Sourcery

Update hard-coded GitHub and Codecov branch references from `master` to `main` to reflect the repository’s default branch rename.

Bug Fixes:
- Ensure README Codecov coverage badge targets the `main` branch so coverage links remain valid.
- Fix GitHub greetings workflow Contributing Guide link to point to the `main` branch.
- Correct changelog permalink to the STDP test file to reference the `main` branch path.