### PR TITLE
chore(release): 2.8.2

### DIFF
--- a/brainpy/_version.py
+++ b/brainpy/_version.py
@@ -14,5 +14,5 @@
 # limitations under the License.
 # ==============================================================================
 
-__version__ = "2.8.1"
+__version__ = "2.8.2"
 __version_info__ = tuple(map(int, __version__.split(".")))

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Version 2.8.2
+
+**Release Date:** July 23, 2026
+
+Version 2.8.2 is a maintenance release focused on compatibility, documentation, and CI/release infrastructure. It restores compatibility with JAX >= 0.11, completes the `master` → `main` branch rename started in 2.8.1, and fixes the Codecov coverage badge, which had been stuck reporting "unknown" because Codecov's own project settings still pointed at the retired `master` branch.
+
+### Bug Fixes
+- Import `concrete_or_error` from `jax.extend.core` on JAX >= 0.11, where it was removed from `jax.interpreters.partial_eval` (#871).
+- `docs/api.rst`: use single-backtick toctree link syntax for the `brainpy.state` entry so it renders as a working external link instead of plain text.
+
+### Documentation
+- Add a `brainpy.state` relationship admonition to the API reference and repoint `brainpy.state` doc links at the canonical `brainx.chaobrain.com/brainpy-state` URLs, replacing the outdated `brainpy-state.readthedocs.io` links (#873).
+
+### Build and Tooling
+- Finish updating branch references from `master` to `main` across the repository (#870).
+- Bump `actions/setup-python` from 6 to 7 in CI (#872).
+- Add `codecov.yml` pinning `codecov.branch: main` so Codecov tracks `main` as the default branch and the README coverage badge reports real coverage instead of "unknown".
+
+
 ## Version 2.8.1
 
 **Release Date:** July 9, 2026

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+codecov:
+  branch: main

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -20,7 +20,7 @@ API Documentation
    apis/optim.rst
    apis/running.rst
    apis/mixin.rst
-   ``brainpy.state`` module <https://brainx.chaobrain.com/brainpy-state/apis/index.html>
+   `brainpy.state` module <https://brainx.chaobrain.com/brainpy-state/apis/index.html>
 
 .. admonition:: ``brainpy`` and ``brainpy.state``
 


### PR DESCRIPTION
## Summary
- Bump version to 2.8.2 (`brainpy/_version.py`)
- Fix the Codecov coverage badge, which was stuck showing "unknown" — Codecov's project settings still pointed at the retired `master` branch after the `main` rename in #870; adding `codecov.yml` with `codecov.branch: main` fixes it
- Fix invalid toctree link syntax in `docs/api.rst` (double backticks → single backtick for the `brainpy.state` external link entry)
- Add the 2.8.2 changelog entry

## Test plan
- [x] `brainpy/_version.py` reads `2.8.2`
- [x] Verified via Codecov's public API that the repo's stored default branch was `master` while `main`'s latest processed commit report was missing — root cause of the "unknown" badge
- [x] CI on this branch

## Summary by Sourcery

Prepare the 2.8.2 maintenance release with updated versioning, documentation, and coverage configuration.

Bug Fixes:
- Correct the `docs/api.rst` toctree link syntax for the `brainpy.state` entry so it renders as a working external link.

Enhancements:
- Add a detailed 2.8.2 changelog entry describing compatibility, documentation, and tooling changes.

Build:
- Bump the recorded package version to 2.8.2 in `brainpy/_version.py`.
- Add `codecov.yml` to pin the default tracked branch to `main` and ensure the coverage badge reports correctly.

Documentation:
- Update the changelog with the 2.8.2 release notes, including bug fixes and tooling changes.